### PR TITLE
FLOW-2880: Allow searching on SQL Server unicode columns

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -50,3 +50,9 @@ com_crashlytics_export_strings.xml
 # Generated properties
 *.properties
 dependency-reduced-pom.xml
+
+# VSCode
+.classpath
+.project
+.settings
+.vscode

--- a/src/main/java/com/manywho/services/sql/services/filter/QueryFilterConditions.java
+++ b/src/main/java/com/manywho/services/sql/services/filter/QueryFilterConditions.java
@@ -35,6 +35,8 @@ public class QueryFilterConditions {
         Map<String, String> stringishColumns = columns.entrySet().stream()
                 .filter(column -> column.getValue().equals(JDBCType.VARCHAR.getName()) ||
                                     column.getValue().equals(JDBCType.NVARCHAR.getName()) ||
+                                    column.getValue().equals(JDBCType.CHAR.getName()) ||
+                                    column.getValue().equals(JDBCType.NCHAR.getName()) ||
                                     column.getValue().equals(JDBCType.LONGVARCHAR.getName()) ||
                                     column.getValue().equals(JDBCType.LONGNVARCHAR.getName()))
                 .collect(Collectors.toMap(

--- a/src/test/java/com/manywho/services/sql/suites/MySqlTestSuite.java
+++ b/src/test/java/com/manywho/services/sql/suites/MySqlTestSuite.java
@@ -7,6 +7,7 @@ import com.manywho.services.sql.suites.mysql.data.AutoIncrementTest;
 import com.manywho.services.sql.suites.mysql.data.CapitalLetterTest;
 import com.manywho.services.sql.suites.mysql.data.LoadBooleanTest;
 import com.manywho.services.sql.suites.mysql.describe.DescribeViewTest;
+import com.manywho.services.sql.suites.mysql.data.SearchTest;
 import org.junit.BeforeClass;
 import org.junit.runner.RunWith;
 import org.junit.runners.Suite;
@@ -26,7 +27,8 @@ import org.junit.runners.Suite;
         LoadBooleanTest.class,
         com.manywho.services.sql.suites.mysql.describe.DescribeTest.class,
         com.manywho.services.sql.suites.mysql.data.SaveTest.class,
-        DescribeViewTest.class
+        DescribeViewTest.class,
+        SearchTest.class
 })
 public class MySqlTestSuite {
     @BeforeClass

--- a/src/test/java/com/manywho/services/sql/suites/PostgreSqlTestSuite.java
+++ b/src/test/java/com/manywho/services/sql/suites/PostgreSqlTestSuite.java
@@ -32,7 +32,8 @@ import org.junit.runners.Suite;
         com.manywho.services.sql.suites.postgresql.data.LoadTest.class,
         com.manywho.services.sql.suites.postgresql.data.DeleteTest.class,
         com.manywho.services.sql.suites.postgresql.data.SaveTest.class,
-        com.manywho.services.sql.suites.postgresql.describe.DescribeTest.class
+        com.manywho.services.sql.suites.postgresql.describe.DescribeTest.class,
+        SearchTest.class
 
 })
 public class PostgreSqlTestSuite {

--- a/src/test/java/com/manywho/services/sql/suites/SqlServerTestSuite.java
+++ b/src/test/java/com/manywho/services/sql/suites/SqlServerTestSuite.java
@@ -10,6 +10,7 @@ import com.manywho.services.sql.suites.sqlserver.data.AutoIncrementTest;
 import com.manywho.services.sql.suites.sqlserver.data.DateTimeTest;
 import com.manywho.services.sql.suites.sqlserver.data.CapitalLetterTest;
 import com.manywho.services.sql.suites.sqlserver.describe.DescribeTest;
+import com.manywho.services.sql.suites.sqlserver.data.SearchTest;
 import org.junit.BeforeClass;
 import org.junit.runner.RunWith;
 import org.junit.runners.Suite;
@@ -25,7 +26,8 @@ import org.junit.runners.Suite;
         DescribeTest.class,
         DateTimeTest.class,
         CapitalLetterTest.class,
-        AutoIncrementTest.class
+        AutoIncrementTest.class,
+        SearchTest.class
 })
 public class SqlServerTestSuite {
     @BeforeClass

--- a/src/test/java/com/manywho/services/sql/suites/mysql/data/SearchTest.java
+++ b/src/test/java/com/manywho/services/sql/suites/mysql/data/SearchTest.java
@@ -1,0 +1,142 @@
+package com.manywho.services.sql.suites.mysql.data;
+
+import com.manywho.services.sql.DbConfigurationTest;
+import com.manywho.services.sql.ServiceFunctionalTest;
+import com.manywho.services.sql.utilities.DefaultApiRequest;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.sql2o.Connection;
+
+public class SearchTest extends ServiceFunctionalTest {
+
+    @Before
+    public void setupDatabase() throws Exception {
+        DbConfigurationTest.setPropertiesIfNotInitialized("mysql");
+        try (Connection connection = getSql2o().open()) {
+            String sql = String.format(
+                "CREATE TABLE %s (" +
+                "id INT NOT NULL PRIMARY KEY," +
+                "col_char CHAR(10)," +
+                "col_varchar VARCHAR(10)," +
+                "col_tinytext TINYTEXT," +
+                "col_text TEXT," +
+                "col_mediumtext MEDIUMTEXT," +
+                "col_longtext LONGTEXT" +
+                ")",
+            escapeTableName("searchtest"));
+
+            connection.createQuery(sql).executeUpdate();
+
+            String sql2 = String.format("INSERT INTO %s (id, col_char, col_varchar, col_tinytext, col_text, col_mediumtext, col_longtext) VALUES " +
+                "(1, 'aaaa', 'xxxx', 'xxxx', 'xxxx', 'xxxx', 'xxxx')," +
+                "(2, 'xxxx', 'bbbb', 'xxxx', 'xxxx', 'xxxx', 'xxxx')," +
+                "(3, 'xxxx', 'xxxx', 'cccc', 'xxxx', 'xxxx', 'xxxx')," +
+                "(4, 'xxxx', 'xxxx', 'xxxx', 'dddd', 'xxxx', 'xxxx')," +
+                "(5, 'xxxx', 'xxxx', 'xxxx', 'xxxx', 'eeee', 'xxxx')," +
+                "(6, 'xxxx', 'xxxx', 'xxxx', 'xxxx', 'xxxx', 'ffff')," +
+                "(7, 'zzzz', 'zzzz', 'zzzz', 'zzzz', 'zzzz', 'zzzz')",
+                escapeTableName("searchtest"));
+
+            connection.createQuery(sql2).executeUpdate();
+        }
+    }
+
+    @Test
+    public void testSearchChar() throws Exception {
+        DefaultApiRequest.loadDataRequestAndAssertion("/data",
+                "suites/mysql/search/char-request.json",
+                configurationParameters(),
+                "suites/mysql/search/char-response.json",
+                dispatcher
+        );
+    }
+
+    @Test
+    public void testSearchVarchar() throws Exception {
+        DefaultApiRequest.loadDataRequestAndAssertion("/data",
+                "suites/mysql/search/varchar-request.json",
+                configurationParameters(),
+                "suites/mysql/search/varchar-response.json",
+                dispatcher
+        );
+    }
+
+    @Test
+    public void testSearchTinytext() throws Exception {
+        DefaultApiRequest.loadDataRequestAndAssertion("/data",
+                "suites/mysql/search/tinytext-request.json",
+                configurationParameters(),
+                "suites/mysql/search/tinytext-response.json",
+                dispatcher
+        );
+    }
+
+    @Test
+    public void testSearchText() throws Exception {
+        DefaultApiRequest.loadDataRequestAndAssertion("/data",
+                "suites/mysql/search/text-request.json",
+                configurationParameters(),
+                "suites/mysql/search/text-response.json",
+                dispatcher
+        );
+    }
+
+    @Test
+    public void testSearchMediumtext() throws Exception {
+        DefaultApiRequest.loadDataRequestAndAssertion("/data",
+                "suites/mysql/search/mediumtext-request.json",
+                configurationParameters(),
+                "suites/mysql/search/mediumtext-response.json",
+                dispatcher
+        );
+    }
+
+    @Test
+    public void testSearchLongtext() throws Exception {
+        DefaultApiRequest.loadDataRequestAndAssertion("/data",
+                "suites/mysql/search/longtext-request.json",
+                configurationParameters(),
+                "suites/mysql/search/longtext-response.json",
+                dispatcher
+        );
+    }
+
+    @Test
+    public void testSearchNoResults() throws Exception {
+        DefaultApiRequest.loadDataRequestAndAssertion("/data",
+                "suites/mysql/search/noresults-request.json",
+                configurationParameters(),
+                "suites/mysql/search/noresults-response.json",
+                dispatcher
+        );
+    }
+
+    @Test
+    public void testSearchAllResults() throws Exception {
+        DefaultApiRequest.loadDataRequestAndAssertion("/data",
+                "suites/mysql/search/allresults-request.json",
+                configurationParameters(),
+                "suites/mysql/search/allresults-response.json",
+                dispatcher
+        );
+    }
+
+    @Test
+    public void testSearchXxxx() throws Exception {
+        // Five rows - all bar the zzzz row
+        DefaultApiRequest.loadDataRequestAndAssertion("/data",
+                "suites/mysql/search/xxxx-request.json",
+                configurationParameters(),
+                "suites/mysql/search/xxxx-response.json",
+                dispatcher
+        );
+    }
+
+    @After
+    public void cleanDatabaseAfterEachTest() throws ClassNotFoundException {
+        try (Connection connection = getSql2o().open()) {
+             deleteTableIfExist("searchtest", connection);
+        }
+    }
+}

--- a/src/test/java/com/manywho/services/sql/suites/postgresql/data/SearchTest.java
+++ b/src/test/java/com/manywho/services/sql/suites/postgresql/data/SearchTest.java
@@ -1,0 +1,106 @@
+package com.manywho.services.sql.suites.postgresql.data;
+
+import com.manywho.services.sql.DbConfigurationTest;
+import com.manywho.services.sql.ServiceFunctionalTest;
+import com.manywho.services.sql.utilities.DefaultApiRequest;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.sql2o.Connection;
+
+public class SearchTest extends ServiceFunctionalTest {
+
+    @Before
+    public void setupDatabase() throws Exception {
+        DbConfigurationTest.setPropertiesIfNotInitialized("postgresql");
+        try (Connection connection = getSql2o().open()) {
+            String sql = String.format(
+                "CREATE TABLE %s (" +
+                "id INT NOT NULL PRIMARY KEY," +
+                "col_char CHAR(10)," +
+                "col_varchar VARCHAR(10)," +
+                "col_text TEXT" +
+                ")",
+            escapeTableName("searchtest"));
+
+            connection.createQuery(sql).executeUpdate();
+
+            String sql2 = String.format("INSERT INTO %s (id, col_char, col_varchar, col_text) VALUES " +
+                "(1, 'aaaa', 'xxxx', 'xxxx')," +
+                "(2, 'xxxx', 'bbbb', 'xxxx')," +
+                "(3, 'xxxx', 'xxxx', 'cccc')," +
+                "(4, 'zzzz', 'zzzz', 'zzzz')",
+                escapeTableName("searchtest"));
+
+            connection.createQuery(sql2).executeUpdate();
+        }
+    }
+
+    @Test
+    public void testSearchChar() throws Exception {
+        DefaultApiRequest.loadDataRequestAndAssertion("/data",
+                "suites/postgresql/search/char-request.json",
+                configurationParameters(),
+                "suites/postgresql/search/char-response.json",
+                dispatcher
+        );
+    }
+
+    @Test
+    public void testSearchVarchar() throws Exception {
+        DefaultApiRequest.loadDataRequestAndAssertion("/data",
+                "suites/postgresql/search/varchar-request.json",
+                configurationParameters(),
+                "suites/postgresql/search/varchar-response.json",
+                dispatcher
+        );
+    }
+
+    @Test
+    public void testSearchText() throws Exception {
+        DefaultApiRequest.loadDataRequestAndAssertion("/data",
+                "suites/postgresql/search/text-request.json",
+                configurationParameters(),
+                "suites/postgresql/search/text-response.json",
+                dispatcher
+        );
+    }
+
+    @Test
+    public void testSearchNoResults() throws Exception {
+        DefaultApiRequest.loadDataRequestAndAssertion("/data",
+                "suites/postgresql/search/noresults-request.json",
+                configurationParameters(),
+                "suites/postgresql/search/noresults-response.json",
+                dispatcher
+        );
+    }
+
+    @Test
+    public void testSearchAllResults() throws Exception {
+        DefaultApiRequest.loadDataRequestAndAssertion("/data",
+                "suites/postgresql/search/allresults-request.json",
+                configurationParameters(),
+                "suites/postgresql/search/allresults-response.json",
+                dispatcher
+        );
+    }
+
+    @Test
+    public void testSearchXxxx() throws Exception {
+        // Three rows - all bar the zzzz row
+        DefaultApiRequest.loadDataRequestAndAssertion("/data",
+                "suites/postgresql/search/xxxx-request.json",
+                configurationParameters(),
+                "suites/postgresql/search/xxxx-response.json",
+                dispatcher
+        );
+    }
+
+    @After
+    public void cleanDatabaseAfterEachTest() throws ClassNotFoundException {
+        try (Connection connection = getSql2o().open()) {
+             deleteTableIfExist("searchtest", connection);
+        }
+    }
+}

--- a/src/test/java/com/manywho/services/sql/suites/sqlserver/data/SearchTest.java
+++ b/src/test/java/com/manywho/services/sql/suites/sqlserver/data/SearchTest.java
@@ -1,0 +1,142 @@
+package com.manywho.services.sql.suites.sqlserver.data;
+
+import com.manywho.services.sql.DbConfigurationTest;
+import com.manywho.services.sql.ServiceFunctionalTest;
+import com.manywho.services.sql.utilities.DefaultApiRequest;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.sql2o.Connection;
+
+public class SearchTest extends ServiceFunctionalTest {
+
+    @Before
+    public void setupDatabase() throws Exception {
+        DbConfigurationTest.setPropertiesIfNotInitialized("sqlserver");
+        try (Connection connection = getSql2o().open()) {
+            String sql = String.format(
+                "CREATE TABLE %s (" +
+                "id INT NOT NULL PRIMARY KEY," +
+                "col_char CHAR(10)," +
+                "col_nchar NCHAR(10)," +
+                "col_varchar VARCHAR(10)," +
+                "col_nvarchar NVARCHAR(10)," +
+                "col_text TEXT," +
+                "col_ntext NTEXT" +
+                ")",
+            escapeTableName("searchtest"));
+
+            connection.createQuery(sql).executeUpdate();
+
+            String sql2 = String.format("INSERT INTO %s (id, col_char, col_nchar, col_varchar, col_nvarchar, col_text, col_ntext) VALUES " +
+                "(1, 'aaaa', 'xxxx', 'xxxx', 'xxxx', 'xxxx', 'xxxx')," +
+                "(2, 'xxxx', 'bbbb', 'xxxx', 'xxxx', 'xxxx', 'xxxx')," +
+                "(3, 'xxxx', 'xxxx', 'cccc', 'xxxx', 'xxxx', 'xxxx')," +
+                "(4, 'xxxx', 'xxxx', 'xxxx', 'dddd', 'xxxx', 'xxxx')," +
+                "(5, 'xxxx', 'xxxx', 'xxxx', 'xxxx', 'eeee', 'xxxx')," +
+                "(6, 'xxxx', 'xxxx', 'xxxx', 'xxxx', 'xxxx', 'ffff')," +
+                "(7, 'zzzz', 'zzzz', 'zzzz', 'zzzz', 'zzzz', 'zzzz')",
+                escapeTableName("searchtest"));
+
+            connection.createQuery(sql2).executeUpdate();
+        }
+    }
+
+    @Test
+    public void testSearchChar() throws Exception {
+        DefaultApiRequest.loadDataRequestAndAssertion("/data",
+                "suites/sqlserver/search/char-request.json",
+                configurationParameters(),
+                "suites/sqlserver/search/char-response.json",
+                dispatcher
+        );
+    }
+
+    @Test
+    public void testSearchNchar() throws Exception {
+        DefaultApiRequest.loadDataRequestAndAssertion("/data",
+                "suites/sqlserver/search/nchar-request.json",
+                configurationParameters(),
+                "suites/sqlserver/search/nchar-response.json",
+                dispatcher
+        );
+    }
+
+    @Test
+    public void testSearchVarchar() throws Exception {
+        DefaultApiRequest.loadDataRequestAndAssertion("/data",
+                "suites/sqlserver/search/varchar-request.json",
+                configurationParameters(),
+                "suites/sqlserver/search/varchar-response.json",
+                dispatcher
+        );
+    }
+
+    @Test
+    public void testSearchNvarchar() throws Exception {
+        DefaultApiRequest.loadDataRequestAndAssertion("/data",
+                "suites/sqlserver/search/nvarchar-request.json",
+                configurationParameters(),
+                "suites/sqlserver/search/nvarchar-response.json",
+                dispatcher
+        );
+    }
+
+    @Test
+    public void testSearchText() throws Exception {
+        DefaultApiRequest.loadDataRequestAndAssertion("/data",
+                "suites/sqlserver/search/text-request.json",
+                configurationParameters(),
+                "suites/sqlserver/search/text-response.json",
+                dispatcher
+        );
+    }
+
+    @Test
+    public void testSearchNtext() throws Exception {
+        DefaultApiRequest.loadDataRequestAndAssertion("/data",
+                "suites/sqlserver/search/ntext-request.json",
+                configurationParameters(),
+                "suites/sqlserver/search/ntext-response.json",
+                dispatcher
+        );
+    }
+
+    @Test
+    public void testSearchNoResults() throws Exception {
+        DefaultApiRequest.loadDataRequestAndAssertion("/data",
+                "suites/sqlserver/search/noresults-request.json",
+                configurationParameters(),
+                "suites/sqlserver/search/noresults-response.json",
+                dispatcher
+        );
+    }
+
+    @Test
+    public void testSearchAllResults() throws Exception {
+        DefaultApiRequest.loadDataRequestAndAssertion("/data",
+                "suites/sqlserver/search/allresults-request.json",
+                configurationParameters(),
+                "suites/sqlserver/search/allresults-response.json",
+                dispatcher
+        );
+    }
+
+    @Test
+    public void testSearchXxxx() throws Exception {
+        // Five rows - all bar the zzzz row
+        DefaultApiRequest.loadDataRequestAndAssertion("/data",
+                "suites/sqlserver/search/xxxx-request.json",
+                configurationParameters(),
+                "suites/sqlserver/search/xxxx-response.json",
+                dispatcher
+        );
+    }
+
+    @After
+    public void cleanDatabaseAfterEachTest() throws ClassNotFoundException {
+        try (Connection connection = getSql2o().open()) {
+             deleteTableIfExist("searchtest", connection);
+        }
+    }
+}

--- a/src/test/resources/suites/mysql/search/allresults-request.json
+++ b/src/test/resources/suites/mysql/search/allresults-request.json
@@ -1,0 +1,160 @@
+{
+    "stateId": null,
+    "token": null,
+    "typeElementBindingId": null,
+    "authorization": {
+        "users": null,
+        "groups": null,
+        "runningAuthenticationId": null,
+        "globalAuthenticationType": "PUBLIC"
+    },
+    "configurationValues": [
+        {
+            "valueElementId": null,
+            "typeElementId": null,
+            "typeElementPropertyId": null,
+            "developerName": "Password",
+            "typeElementDeveloperName": null,
+            "typeElementPropertyDeveloperName": null,
+            "contentValue": "{{password}}",
+            "contentType": "ContentPassword",
+            "objectData": null
+        },
+        {
+            "valueElementId": null,
+            "typeElementId": null,
+            "typeElementPropertyId": null,
+            "developerName": "Database Type",
+            "typeElementDeveloperName": null,
+            "typeElementPropertyDeveloperName": null,
+            "contentValue": "{{databaseType}}",
+            "contentType": "ContentString",
+            "objectData": null
+        },
+        {
+            "valueElementId": null,
+            "typeElementId": null,
+            "typeElementPropertyId": null,
+            "developerName": "Database Name",
+            "typeElementDeveloperName": null,
+            "typeElementPropertyDeveloperName": null,
+            "contentValue": "{{databaseName}}",
+            "contentType": "ContentString",
+            "objectData": null
+        },
+        {
+            "valueElementId": null,
+            "typeElementId": null,
+            "typeElementPropertyId": null,
+            "developerName": "Port",
+            "typeElementDeveloperName": null,
+            "typeElementPropertyDeveloperName": null,
+            "contentValue": "{{port}}",
+            "contentType": "ContentNumber",
+            "objectData": null
+        },
+        {
+            "valueElementId": null,
+            "typeElementId": null,
+            "typeElementPropertyId": null,
+            "developerName": "Host",
+            "typeElementDeveloperName": null,
+            "typeElementPropertyDeveloperName": null,
+            "contentValue": "{{host}}",
+            "contentType": "ContentString",
+            "objectData": null
+        },
+        {
+            "valueElementId": null,
+            "typeElementId": null,
+            "typeElementPropertyId": null,
+            "developerName": "Database Schema",
+            "typeElementDeveloperName": null,
+            "typeElementPropertyDeveloperName": null,
+            "contentValue": "{{schema}}",
+            "contentType": "ContentString",
+            "objectData": null
+        },
+        {
+            "valueElementId": null,
+            "typeElementId": null,
+            "typeElementPropertyId": null,
+            "developerName": "Username",
+            "typeElementDeveloperName": null,
+            "typeElementPropertyDeveloperName": null,
+            "contentValue": "{{userName}}",
+            "contentType": "ContentString",
+            "objectData": null
+        },
+        {
+            "valueElementId": null,
+            "typeElementId": null,
+            "typeElementPropertyId": null,
+            "developerName": "No SSL",
+            "typeElementDeveloperName": null,
+            "typeElementPropertyDeveloperName": null,
+            "contentValue": "true",
+            "contentType": null,
+            "objectData": null
+        }
+    ],
+    "command": null,
+    "culture": {
+        "id": null,
+        "developerName": null,
+        "developerSummary": null,
+        "brand": null,
+        "language": "EN",
+        "country": "USA",
+        "variant": null
+    },
+    "listFilter": {
+        "id": null,
+        "filterByProvidedObjects": false,
+        "orderByPropertyDeveloperName": "id",
+        "orderByDirectionType": "",
+        "orderBy": null,
+        "limit": 0,
+        "offset": 0,
+        "search": null,
+        "searchCriteria": null,
+        "comparisonType": "OR",
+        "where": null,
+        "listFilters": null
+    },
+    "objectDataType": {
+        "typeElementId": "737809a7-5825-4b04-8d38-b271963732e5",
+        "developerName": "searchtest",
+        "properties": [
+            {
+                "developerName": "id",
+                "list": null
+            },
+            {
+                "developerName": "col_char",
+                "list": null
+            },
+            {
+                "developerName": "col_varchar",
+                "list": null
+            },
+            {
+                "developerName": "col_tinytext",
+                "list": null
+            },
+            {
+                "developerName": "col_text",
+                "list": null
+            },
+            {
+                "developerName": "col_mediumtext",
+                "list": null
+            },
+            {
+                "developerName": "col_longtext",
+                "list": null
+            }
+        ]
+    },
+    "objectData": null
+}

--- a/src/test/resources/suites/mysql/search/allresults-response.json
+++ b/src/test/resources/suites/mysql/search/allresults-response.json
@@ -1,0 +1,468 @@
+{
+    "culture": null,
+    "hasMoreResults": false,
+    "objectData": [
+        {
+            "internalId": null,
+            "externalId": "eyJpZCI6IjEifQ==",
+            "developerName": "searchtest",
+            "typeElementId": null,
+            "order": 0,
+            "properties": [
+                {
+                    "typeElementPropertyId": null,
+                    "developerName": "id",
+                    "contentType": "ContentNumber",
+                    "contentValue": "1",
+                    "contentFormat": null,
+                    "objectData": []
+                },
+                {
+                    "typeElementPropertyId": null,
+                    "developerName": "col_char",
+                    "contentType": "ContentString",
+                    "contentValue": "aaaa",
+                    "contentFormat": null,
+                    "objectData": []
+                },
+                {
+                    "typeElementPropertyId": null,
+                    "developerName": "col_varchar",
+                    "contentType": "ContentString",
+                    "contentValue": "xxxx",
+                    "contentFormat": null,
+                    "objectData": []
+                },
+                {
+                    "typeElementPropertyId": null,
+                    "developerName": "col_tinytext",
+                    "contentType": "ContentString",
+                    "contentValue": "xxxx",
+                    "contentFormat": null,
+                    "objectData": []
+                },
+                {
+                    "typeElementPropertyId": null,
+                    "developerName": "col_text",
+                    "contentType": "ContentString",
+                    "contentValue": "xxxx",
+                    "contentFormat": null,
+                    "objectData": []
+                },
+                {
+                    "typeElementPropertyId": null,
+                    "developerName": "col_mediumtext",
+                    "contentType": "ContentString",
+                    "contentValue": "xxxx",
+                    "contentFormat": null,
+                    "objectData": []
+                },
+                {
+                    "typeElementPropertyId": null,
+                    "developerName": "col_longtext",
+                    "contentType": "ContentString",
+                    "contentValue": "xxxx",
+                    "contentFormat": null,
+                    "objectData": []
+                }
+            ],
+            "isSelected": false
+        },
+        {
+            "internalId": null,
+            "externalId": "eyJpZCI6IjIifQ==",
+            "developerName": "searchtest",
+            "typeElementId": null,
+            "order": 0,
+            "properties": [
+                {
+                    "typeElementPropertyId": null,
+                    "developerName": "id",
+                    "contentType": "ContentNumber",
+                    "contentValue": "2",
+                    "contentFormat": null,
+                    "objectData": []
+                },
+                {
+                    "typeElementPropertyId": null,
+                    "developerName": "col_char",
+                    "contentType": "ContentString",
+                    "contentValue": "xxxx",
+                    "contentFormat": null,
+                    "objectData": []
+                },
+                {
+                    "typeElementPropertyId": null,
+                    "developerName": "col_varchar",
+                    "contentType": "ContentString",
+                    "contentValue": "bbbb",
+                    "contentFormat": null,
+                    "objectData": []
+                },
+                {
+                    "typeElementPropertyId": null,
+                    "developerName": "col_tinytext",
+                    "contentType": "ContentString",
+                    "contentValue": "xxxx",
+                    "contentFormat": null,
+                    "objectData": []
+                },
+                {
+                    "typeElementPropertyId": null,
+                    "developerName": "col_text",
+                    "contentType": "ContentString",
+                    "contentValue": "xxxx",
+                    "contentFormat": null,
+                    "objectData": []
+                },
+                {
+                    "typeElementPropertyId": null,
+                    "developerName": "col_mediumtext",
+                    "contentType": "ContentString",
+                    "contentValue": "xxxx",
+                    "contentFormat": null,
+                    "objectData": []
+                },
+                {
+                    "typeElementPropertyId": null,
+                    "developerName": "col_longtext",
+                    "contentType": "ContentString",
+                    "contentValue": "xxxx",
+                    "contentFormat": null,
+                    "objectData": []
+                }
+            ],
+            "isSelected": false
+        },
+        {
+            "internalId": null,
+            "externalId": "eyJpZCI6IjMifQ==",
+            "developerName": "searchtest",
+            "typeElementId": null,
+            "order": 0,
+            "properties": [
+                {
+                    "typeElementPropertyId": null,
+                    "developerName": "id",
+                    "contentType": "ContentNumber",
+                    "contentValue": "3",
+                    "contentFormat": null,
+                    "objectData": []
+                },
+                {
+                    "typeElementPropertyId": null,
+                    "developerName": "col_char",
+                    "contentType": "ContentString",
+                    "contentValue": "xxxx",
+                    "contentFormat": null,
+                    "objectData": []
+                },
+                {
+                    "typeElementPropertyId": null,
+                    "developerName": "col_varchar",
+                    "contentType": "ContentString",
+                    "contentValue": "xxxx",
+                    "contentFormat": null,
+                    "objectData": []
+                },
+                {
+                    "typeElementPropertyId": null,
+                    "developerName": "col_tinytext",
+                    "contentType": "ContentString",
+                    "contentValue": "cccc",
+                    "contentFormat": null,
+                    "objectData": []
+                },
+                {
+                    "typeElementPropertyId": null,
+                    "developerName": "col_text",
+                    "contentType": "ContentString",
+                    "contentValue": "xxxx",
+                    "contentFormat": null,
+                    "objectData": []
+                },
+                {
+                    "typeElementPropertyId": null,
+                    "developerName": "col_mediumtext",
+                    "contentType": "ContentString",
+                    "contentValue": "xxxx",
+                    "contentFormat": null,
+                    "objectData": []
+                },
+                {
+                    "typeElementPropertyId": null,
+                    "developerName": "col_longtext",
+                    "contentType": "ContentString",
+                    "contentValue": "xxxx",
+                    "contentFormat": null,
+                    "objectData": []
+                }
+            ],
+            "isSelected": false
+        },
+        {
+            "internalId": null,
+            "externalId": "eyJpZCI6IjQifQ==",
+            "developerName": "searchtest",
+            "typeElementId": null,
+            "order": 0,
+            "properties": [
+                {
+                    "typeElementPropertyId": null,
+                    "developerName": "id",
+                    "contentType": "ContentNumber",
+                    "contentValue": "4",
+                    "contentFormat": null,
+                    "objectData": []
+                },
+                {
+                    "typeElementPropertyId": null,
+                    "developerName": "col_char",
+                    "contentType": "ContentString",
+                    "contentValue": "xxxx",
+                    "contentFormat": null,
+                    "objectData": []
+                },
+                {
+                    "typeElementPropertyId": null,
+                    "developerName": "col_varchar",
+                    "contentType": "ContentString",
+                    "contentValue": "xxxx",
+                    "contentFormat": null,
+                    "objectData": []
+                },
+                {
+                    "typeElementPropertyId": null,
+                    "developerName": "col_tinytext",
+                    "contentType": "ContentString",
+                    "contentValue": "xxxx",
+                    "contentFormat": null,
+                    "objectData": []
+                },
+                {
+                    "typeElementPropertyId": null,
+                    "developerName": "col_text",
+                    "contentType": "ContentString",
+                    "contentValue": "dddd",
+                    "contentFormat": null,
+                    "objectData": []
+                },
+                {
+                    "typeElementPropertyId": null,
+                    "developerName": "col_mediumtext",
+                    "contentType": "ContentString",
+                    "contentValue": "xxxx",
+                    "contentFormat": null,
+                    "objectData": []
+                },
+                {
+                    "typeElementPropertyId": null,
+                    "developerName": "col_longtext",
+                    "contentType": "ContentString",
+                    "contentValue": "xxxx",
+                    "contentFormat": null,
+                    "objectData": []
+                }
+            ],
+            "isSelected": false
+        },
+        {
+            "internalId": null,
+            "externalId": "eyJpZCI6IjUifQ==",
+            "developerName": "searchtest",
+            "typeElementId": null,
+            "order": 0,
+            "properties": [
+                {
+                    "typeElementPropertyId": null,
+                    "developerName": "id",
+                    "contentType": "ContentNumber",
+                    "contentValue": "5",
+                    "contentFormat": null,
+                    "objectData": []
+                },
+                {
+                    "typeElementPropertyId": null,
+                    "developerName": "col_char",
+                    "contentType": "ContentString",
+                    "contentValue": "xxxx",
+                    "contentFormat": null,
+                    "objectData": []
+                },
+                {
+                    "typeElementPropertyId": null,
+                    "developerName": "col_varchar",
+                    "contentType": "ContentString",
+                    "contentValue": "xxxx",
+                    "contentFormat": null,
+                    "objectData": []
+                },
+                {
+                    "typeElementPropertyId": null,
+                    "developerName": "col_tinytext",
+                    "contentType": "ContentString",
+                    "contentValue": "xxxx",
+                    "contentFormat": null,
+                    "objectData": []
+                },
+                {
+                    "typeElementPropertyId": null,
+                    "developerName": "col_text",
+                    "contentType": "ContentString",
+                    "contentValue": "xxxx",
+                    "contentFormat": null,
+                    "objectData": []
+                },
+                {
+                    "typeElementPropertyId": null,
+                    "developerName": "col_mediumtext",
+                    "contentType": "ContentString",
+                    "contentValue": "eeee",
+                    "contentFormat": null,
+                    "objectData": []
+                },
+                {
+                    "typeElementPropertyId": null,
+                    "developerName": "col_longtext",
+                    "contentType": "ContentString",
+                    "contentValue": "xxxx",
+                    "contentFormat": null,
+                    "objectData": []
+                }
+            ],
+            "isSelected": false
+        },
+        {
+            "internalId": null,
+            "externalId": "eyJpZCI6IjYifQ==",
+            "developerName": "searchtest",
+            "typeElementId": null,
+            "order": 0,
+            "properties": [
+                {
+                    "typeElementPropertyId": null,
+                    "developerName": "id",
+                    "contentType": "ContentNumber",
+                    "contentValue": "6",
+                    "contentFormat": null,
+                    "objectData": []
+                },
+                {
+                    "typeElementPropertyId": null,
+                    "developerName": "col_char",
+                    "contentType": "ContentString",
+                    "contentValue": "xxxx",
+                    "contentFormat": null,
+                    "objectData": []
+                },
+                {
+                    "typeElementPropertyId": null,
+                    "developerName": "col_varchar",
+                    "contentType": "ContentString",
+                    "contentValue": "xxxx",
+                    "contentFormat": null,
+                    "objectData": []
+                },
+                {
+                    "typeElementPropertyId": null,
+                    "developerName": "col_tinytext",
+                    "contentType": "ContentString",
+                    "contentValue": "xxxx",
+                    "contentFormat": null,
+                    "objectData": []
+                },
+                {
+                    "typeElementPropertyId": null,
+                    "developerName": "col_text",
+                    "contentType": "ContentString",
+                    "contentValue": "xxxx",
+                    "contentFormat": null,
+                    "objectData": []
+                },
+                {
+                    "typeElementPropertyId": null,
+                    "developerName": "col_mediumtext",
+                    "contentType": "ContentString",
+                    "contentValue": "xxxx",
+                    "contentFormat": null,
+                    "objectData": []
+                },
+                {
+                    "typeElementPropertyId": null,
+                    "developerName": "col_longtext",
+                    "contentType": "ContentString",
+                    "contentValue": "ffff",
+                    "contentFormat": null,
+                    "objectData": []
+                }
+            ],
+            "isSelected": false
+        },
+        {
+            "internalId": null,
+            "externalId": "eyJpZCI6IjcifQ==",
+            "developerName": "searchtest",
+            "typeElementId": null,
+            "order": 0,
+            "properties": [
+                {
+                    "typeElementPropertyId": null,
+                    "developerName": "id",
+                    "contentType": "ContentNumber",
+                    "contentValue": "7",
+                    "contentFormat": null,
+                    "objectData": []
+                },
+                {
+                    "typeElementPropertyId": null,
+                    "developerName": "col_char",
+                    "contentType": "ContentString",
+                    "contentValue": "zzzz",
+                    "contentFormat": null,
+                    "objectData": []
+                },
+                {
+                    "typeElementPropertyId": null,
+                    "developerName": "col_varchar",
+                    "contentType": "ContentString",
+                    "contentValue": "zzzz",
+                    "contentFormat": null,
+                    "objectData": []
+                },
+                {
+                    "typeElementPropertyId": null,
+                    "developerName": "col_tinytext",
+                    "contentType": "ContentString",
+                    "contentValue": "zzzz",
+                    "contentFormat": null,
+                    "objectData": []
+                },
+                {
+                    "typeElementPropertyId": null,
+                    "developerName": "col_text",
+                    "contentType": "ContentString",
+                    "contentValue": "zzzz",
+                    "contentFormat": null,
+                    "objectData": []
+                },
+                {
+                    "typeElementPropertyId": null,
+                    "developerName": "col_mediumtext",
+                    "contentType": "ContentString",
+                    "contentValue": "zzzz",
+                    "contentFormat": null,
+                    "objectData": []
+                },
+                {
+                    "typeElementPropertyId": null,
+                    "developerName": "col_longtext",
+                    "contentType": "ContentString",
+                    "contentValue": "zzzz",
+                    "contentFormat": null,
+                    "objectData": []
+                }
+            ],
+            "isSelected": false
+        }
+    ]
+}

--- a/src/test/resources/suites/mysql/search/char-request.json
+++ b/src/test/resources/suites/mysql/search/char-request.json
@@ -1,0 +1,160 @@
+{
+    "stateId": null,
+    "token": null,
+    "typeElementBindingId": null,
+    "authorization": {
+        "users": null,
+        "groups": null,
+        "runningAuthenticationId": null,
+        "globalAuthenticationType": "PUBLIC"
+    },
+    "configurationValues": [
+        {
+            "valueElementId": null,
+            "typeElementId": null,
+            "typeElementPropertyId": null,
+            "developerName": "Password",
+            "typeElementDeveloperName": null,
+            "typeElementPropertyDeveloperName": null,
+            "contentValue": "{{password}}",
+            "contentType": "ContentPassword",
+            "objectData": null
+        },
+        {
+            "valueElementId": null,
+            "typeElementId": null,
+            "typeElementPropertyId": null,
+            "developerName": "Database Type",
+            "typeElementDeveloperName": null,
+            "typeElementPropertyDeveloperName": null,
+            "contentValue": "{{databaseType}}",
+            "contentType": "ContentString",
+            "objectData": null
+        },
+        {
+            "valueElementId": null,
+            "typeElementId": null,
+            "typeElementPropertyId": null,
+            "developerName": "Database Name",
+            "typeElementDeveloperName": null,
+            "typeElementPropertyDeveloperName": null,
+            "contentValue": "{{databaseName}}",
+            "contentType": "ContentString",
+            "objectData": null
+        },
+        {
+            "valueElementId": null,
+            "typeElementId": null,
+            "typeElementPropertyId": null,
+            "developerName": "Port",
+            "typeElementDeveloperName": null,
+            "typeElementPropertyDeveloperName": null,
+            "contentValue": "{{port}}",
+            "contentType": "ContentNumber",
+            "objectData": null
+        },
+        {
+            "valueElementId": null,
+            "typeElementId": null,
+            "typeElementPropertyId": null,
+            "developerName": "Host",
+            "typeElementDeveloperName": null,
+            "typeElementPropertyDeveloperName": null,
+            "contentValue": "{{host}}",
+            "contentType": "ContentString",
+            "objectData": null
+        },
+        {
+            "valueElementId": null,
+            "typeElementId": null,
+            "typeElementPropertyId": null,
+            "developerName": "Database Schema",
+            "typeElementDeveloperName": null,
+            "typeElementPropertyDeveloperName": null,
+            "contentValue": "{{schema}}",
+            "contentType": "ContentString",
+            "objectData": null
+        },
+        {
+            "valueElementId": null,
+            "typeElementId": null,
+            "typeElementPropertyId": null,
+            "developerName": "Username",
+            "typeElementDeveloperName": null,
+            "typeElementPropertyDeveloperName": null,
+            "contentValue": "{{userName}}",
+            "contentType": "ContentString",
+            "objectData": null
+        },
+        {
+            "valueElementId": null,
+            "typeElementId": null,
+            "typeElementPropertyId": null,
+            "developerName": "No SSL",
+            "typeElementDeveloperName": null,
+            "typeElementPropertyDeveloperName": null,
+            "contentValue": "true",
+            "contentType": null,
+            "objectData": null
+        }
+    ],
+    "command": null,
+    "culture": {
+        "id": null,
+        "developerName": null,
+        "developerSummary": null,
+        "brand": null,
+        "language": "EN",
+        "country": "USA",
+        "variant": null
+    },
+    "listFilter": {
+        "id": null,
+        "filterByProvidedObjects": false,
+        "orderByPropertyDeveloperName": "id",
+        "orderByDirectionType": "",
+        "orderBy": null,
+        "limit": 0,
+        "offset": 0,
+        "search": "aa",
+        "searchCriteria": null,
+        "comparisonType": "OR",
+        "where": null,
+        "listFilters": null
+    },
+    "objectDataType": {
+        "typeElementId": "737809a7-5825-4b04-8d38-b271963732e5",
+        "developerName": "searchtest",
+        "properties": [
+            {
+                "developerName": "id",
+                "list": null
+            },
+            {
+                "developerName": "col_char",
+                "list": null
+            },
+            {
+                "developerName": "col_varchar",
+                "list": null
+            },
+            {
+                "developerName": "col_tinytext",
+                "list": null
+            },
+            {
+                "developerName": "col_text",
+                "list": null
+            },
+            {
+                "developerName": "col_mediumtext",
+                "list": null
+            },
+            {
+                "developerName": "col_longtext",
+                "list": null
+            }
+        ]
+    },
+    "objectData": null
+}

--- a/src/test/resources/suites/mysql/search/char-response.json
+++ b/src/test/resources/suites/mysql/search/char-response.json
@@ -1,0 +1,72 @@
+{
+    "culture": null,
+    "hasMoreResults": false,
+    "objectData": [
+        {
+            "internalId": null,
+            "externalId": "eyJpZCI6IjEifQ==",
+            "developerName": "searchtest",
+            "typeElementId": null,
+            "order": 0,
+            "properties": [
+                {
+                    "typeElementPropertyId": null,
+                    "developerName": "id",
+                    "contentType": "ContentNumber",
+                    "contentValue": "1",
+                    "contentFormat": null,
+                    "objectData": []
+                },
+                {
+                    "typeElementPropertyId": null,
+                    "developerName": "col_char",
+                    "contentType": "ContentString",
+                    "contentValue": "aaaa",
+                    "contentFormat": null,
+                    "objectData": []
+                },
+                {
+                    "typeElementPropertyId": null,
+                    "developerName": "col_varchar",
+                    "contentType": "ContentString",
+                    "contentValue": "xxxx",
+                    "contentFormat": null,
+                    "objectData": []
+                },
+                {
+                    "typeElementPropertyId": null,
+                    "developerName": "col_tinytext",
+                    "contentType": "ContentString",
+                    "contentValue": "xxxx",
+                    "contentFormat": null,
+                    "objectData": []
+                },
+                {
+                    "typeElementPropertyId": null,
+                    "developerName": "col_text",
+                    "contentType": "ContentString",
+                    "contentValue": "xxxx",
+                    "contentFormat": null,
+                    "objectData": []
+                },
+                {
+                    "typeElementPropertyId": null,
+                    "developerName": "col_mediumtext",
+                    "contentType": "ContentString",
+                    "contentValue": "xxxx",
+                    "contentFormat": null,
+                    "objectData": []
+                },
+                {
+                    "typeElementPropertyId": null,
+                    "developerName": "col_longtext",
+                    "contentType": "ContentString",
+                    "contentValue": "xxxx",
+                    "contentFormat": null,
+                    "objectData": []
+                }
+            ],
+            "isSelected": false
+        }
+    ]
+}

--- a/src/test/resources/suites/mysql/search/longtext-request.json
+++ b/src/test/resources/suites/mysql/search/longtext-request.json
@@ -1,0 +1,160 @@
+{
+    "stateId": null,
+    "token": null,
+    "typeElementBindingId": null,
+    "authorization": {
+        "users": null,
+        "groups": null,
+        "runningAuthenticationId": null,
+        "globalAuthenticationType": "PUBLIC"
+    },
+    "configurationValues": [
+        {
+            "valueElementId": null,
+            "typeElementId": null,
+            "typeElementPropertyId": null,
+            "developerName": "Password",
+            "typeElementDeveloperName": null,
+            "typeElementPropertyDeveloperName": null,
+            "contentValue": "{{password}}",
+            "contentType": "ContentPassword",
+            "objectData": null
+        },
+        {
+            "valueElementId": null,
+            "typeElementId": null,
+            "typeElementPropertyId": null,
+            "developerName": "Database Type",
+            "typeElementDeveloperName": null,
+            "typeElementPropertyDeveloperName": null,
+            "contentValue": "{{databaseType}}",
+            "contentType": "ContentString",
+            "objectData": null
+        },
+        {
+            "valueElementId": null,
+            "typeElementId": null,
+            "typeElementPropertyId": null,
+            "developerName": "Database Name",
+            "typeElementDeveloperName": null,
+            "typeElementPropertyDeveloperName": null,
+            "contentValue": "{{databaseName}}",
+            "contentType": "ContentString",
+            "objectData": null
+        },
+        {
+            "valueElementId": null,
+            "typeElementId": null,
+            "typeElementPropertyId": null,
+            "developerName": "Port",
+            "typeElementDeveloperName": null,
+            "typeElementPropertyDeveloperName": null,
+            "contentValue": "{{port}}",
+            "contentType": "ContentNumber",
+            "objectData": null
+        },
+        {
+            "valueElementId": null,
+            "typeElementId": null,
+            "typeElementPropertyId": null,
+            "developerName": "Host",
+            "typeElementDeveloperName": null,
+            "typeElementPropertyDeveloperName": null,
+            "contentValue": "{{host}}",
+            "contentType": "ContentString",
+            "objectData": null
+        },
+        {
+            "valueElementId": null,
+            "typeElementId": null,
+            "typeElementPropertyId": null,
+            "developerName": "Database Schema",
+            "typeElementDeveloperName": null,
+            "typeElementPropertyDeveloperName": null,
+            "contentValue": "{{schema}}",
+            "contentType": "ContentString",
+            "objectData": null
+        },
+        {
+            "valueElementId": null,
+            "typeElementId": null,
+            "typeElementPropertyId": null,
+            "developerName": "Username",
+            "typeElementDeveloperName": null,
+            "typeElementPropertyDeveloperName": null,
+            "contentValue": "{{userName}}",
+            "contentType": "ContentString",
+            "objectData": null
+        },
+        {
+            "valueElementId": null,
+            "typeElementId": null,
+            "typeElementPropertyId": null,
+            "developerName": "No SSL",
+            "typeElementDeveloperName": null,
+            "typeElementPropertyDeveloperName": null,
+            "contentValue": "true",
+            "contentType": null,
+            "objectData": null
+        }
+    ],
+    "command": null,
+    "culture": {
+        "id": null,
+        "developerName": null,
+        "developerSummary": null,
+        "brand": null,
+        "language": "EN",
+        "country": "USA",
+        "variant": null
+    },
+    "listFilter": {
+        "id": null,
+        "filterByProvidedObjects": false,
+        "orderByPropertyDeveloperName": "id",
+        "orderByDirectionType": "",
+        "orderBy": null,
+        "limit": 0,
+        "offset": 0,
+        "search": "ff",
+        "searchCriteria": null,
+        "comparisonType": "OR",
+        "where": null,
+        "listFilters": null
+    },
+    "objectDataType": {
+        "typeElementId": "737809a7-5825-4b04-8d38-b271963732e5",
+        "developerName": "searchtest",
+        "properties": [
+            {
+                "developerName": "id",
+                "list": null
+            },
+            {
+                "developerName": "col_char",
+                "list": null
+            },
+            {
+                "developerName": "col_varchar",
+                "list": null
+            },
+            {
+                "developerName": "col_tinytext",
+                "list": null
+            },
+            {
+                "developerName": "col_text",
+                "list": null
+            },
+            {
+                "developerName": "col_mediumtext",
+                "list": null
+            },
+            {
+                "developerName": "col_longtext",
+                "list": null
+            }
+        ]
+    },
+    "objectData": null
+}

--- a/src/test/resources/suites/mysql/search/longtext-response.json
+++ b/src/test/resources/suites/mysql/search/longtext-response.json
@@ -1,0 +1,72 @@
+{
+    "culture": null,
+    "hasMoreResults": false,
+    "objectData": [
+        {
+            "internalId": null,
+            "externalId": "eyJpZCI6IjYifQ==",
+            "developerName": "searchtest",
+            "typeElementId": null,
+            "order": 0,
+            "properties": [
+                {
+                    "typeElementPropertyId": null,
+                    "developerName": "id",
+                    "contentType": "ContentNumber",
+                    "contentValue": "6",
+                    "contentFormat": null,
+                    "objectData": []
+                },
+                {
+                    "typeElementPropertyId": null,
+                    "developerName": "col_char",
+                    "contentType": "ContentString",
+                    "contentValue": "xxxx",
+                    "contentFormat": null,
+                    "objectData": []
+                },
+                {
+                    "typeElementPropertyId": null,
+                    "developerName": "col_varchar",
+                    "contentType": "ContentString",
+                    "contentValue": "xxxx",
+                    "contentFormat": null,
+                    "objectData": []
+                },
+                {
+                    "typeElementPropertyId": null,
+                    "developerName": "col_tinytext",
+                    "contentType": "ContentString",
+                    "contentValue": "xxxx",
+                    "contentFormat": null,
+                    "objectData": []
+                },
+                {
+                    "typeElementPropertyId": null,
+                    "developerName": "col_text",
+                    "contentType": "ContentString",
+                    "contentValue": "xxxx",
+                    "contentFormat": null,
+                    "objectData": []
+                },
+                {
+                    "typeElementPropertyId": null,
+                    "developerName": "col_mediumtext",
+                    "contentType": "ContentString",
+                    "contentValue": "xxxx",
+                    "contentFormat": null,
+                    "objectData": []
+                },
+                {
+                    "typeElementPropertyId": null,
+                    "developerName": "col_longtext",
+                    "contentType": "ContentString",
+                    "contentValue": "ffff",
+                    "contentFormat": null,
+                    "objectData": []
+                }
+            ],
+            "isSelected": false
+        }
+    ]
+}

--- a/src/test/resources/suites/mysql/search/mediumtext-request.json
+++ b/src/test/resources/suites/mysql/search/mediumtext-request.json
@@ -1,0 +1,160 @@
+{
+    "stateId": null,
+    "token": null,
+    "typeElementBindingId": null,
+    "authorization": {
+        "users": null,
+        "groups": null,
+        "runningAuthenticationId": null,
+        "globalAuthenticationType": "PUBLIC"
+    },
+    "configurationValues": [
+        {
+            "valueElementId": null,
+            "typeElementId": null,
+            "typeElementPropertyId": null,
+            "developerName": "Password",
+            "typeElementDeveloperName": null,
+            "typeElementPropertyDeveloperName": null,
+            "contentValue": "{{password}}",
+            "contentType": "ContentPassword",
+            "objectData": null
+        },
+        {
+            "valueElementId": null,
+            "typeElementId": null,
+            "typeElementPropertyId": null,
+            "developerName": "Database Type",
+            "typeElementDeveloperName": null,
+            "typeElementPropertyDeveloperName": null,
+            "contentValue": "{{databaseType}}",
+            "contentType": "ContentString",
+            "objectData": null
+        },
+        {
+            "valueElementId": null,
+            "typeElementId": null,
+            "typeElementPropertyId": null,
+            "developerName": "Database Name",
+            "typeElementDeveloperName": null,
+            "typeElementPropertyDeveloperName": null,
+            "contentValue": "{{databaseName}}",
+            "contentType": "ContentString",
+            "objectData": null
+        },
+        {
+            "valueElementId": null,
+            "typeElementId": null,
+            "typeElementPropertyId": null,
+            "developerName": "Port",
+            "typeElementDeveloperName": null,
+            "typeElementPropertyDeveloperName": null,
+            "contentValue": "{{port}}",
+            "contentType": "ContentNumber",
+            "objectData": null
+        },
+        {
+            "valueElementId": null,
+            "typeElementId": null,
+            "typeElementPropertyId": null,
+            "developerName": "Host",
+            "typeElementDeveloperName": null,
+            "typeElementPropertyDeveloperName": null,
+            "contentValue": "{{host}}",
+            "contentType": "ContentString",
+            "objectData": null
+        },
+        {
+            "valueElementId": null,
+            "typeElementId": null,
+            "typeElementPropertyId": null,
+            "developerName": "Database Schema",
+            "typeElementDeveloperName": null,
+            "typeElementPropertyDeveloperName": null,
+            "contentValue": "{{schema}}",
+            "contentType": "ContentString",
+            "objectData": null
+        },
+        {
+            "valueElementId": null,
+            "typeElementId": null,
+            "typeElementPropertyId": null,
+            "developerName": "Username",
+            "typeElementDeveloperName": null,
+            "typeElementPropertyDeveloperName": null,
+            "contentValue": "{{userName}}",
+            "contentType": "ContentString",
+            "objectData": null
+        },
+        {
+            "valueElementId": null,
+            "typeElementId": null,
+            "typeElementPropertyId": null,
+            "developerName": "No SSL",
+            "typeElementDeveloperName": null,
+            "typeElementPropertyDeveloperName": null,
+            "contentValue": "true",
+            "contentType": null,
+            "objectData": null
+        }
+    ],
+    "command": null,
+    "culture": {
+        "id": null,
+        "developerName": null,
+        "developerSummary": null,
+        "brand": null,
+        "language": "EN",
+        "country": "USA",
+        "variant": null
+    },
+    "listFilter": {
+        "id": null,
+        "filterByProvidedObjects": false,
+        "orderByPropertyDeveloperName": "id",
+        "orderByDirectionType": "",
+        "orderBy": null,
+        "limit": 0,
+        "offset": 0,
+        "search": "ee",
+        "searchCriteria": null,
+        "comparisonType": "OR",
+        "where": null,
+        "listFilters": null
+    },
+    "objectDataType": {
+        "typeElementId": "737809a7-5825-4b04-8d38-b271963732e5",
+        "developerName": "searchtest",
+        "properties": [
+            {
+                "developerName": "id",
+                "list": null
+            },
+            {
+                "developerName": "col_char",
+                "list": null
+            },
+            {
+                "developerName": "col_varchar",
+                "list": null
+            },
+            {
+                "developerName": "col_tinytext",
+                "list": null
+            },
+            {
+                "developerName": "col_text",
+                "list": null
+            },
+            {
+                "developerName": "col_mediumtext",
+                "list": null
+            },
+            {
+                "developerName": "col_longtext",
+                "list": null
+            }
+        ]
+    },
+    "objectData": null
+}

--- a/src/test/resources/suites/mysql/search/mediumtext-response.json
+++ b/src/test/resources/suites/mysql/search/mediumtext-response.json
@@ -1,0 +1,72 @@
+{
+    "culture": null,
+    "hasMoreResults": false,
+    "objectData": [
+        {
+            "internalId": null,
+            "externalId": "eyJpZCI6IjUifQ==",
+            "developerName": "searchtest",
+            "typeElementId": null,
+            "order": 0,
+            "properties": [
+                {
+                    "typeElementPropertyId": null,
+                    "developerName": "id",
+                    "contentType": "ContentNumber",
+                    "contentValue": "5",
+                    "contentFormat": null,
+                    "objectData": []
+                },
+                {
+                    "typeElementPropertyId": null,
+                    "developerName": "col_char",
+                    "contentType": "ContentString",
+                    "contentValue": "xxxx",
+                    "contentFormat": null,
+                    "objectData": []
+                },
+                {
+                    "typeElementPropertyId": null,
+                    "developerName": "col_varchar",
+                    "contentType": "ContentString",
+                    "contentValue": "xxxx",
+                    "contentFormat": null,
+                    "objectData": []
+                },
+                {
+                    "typeElementPropertyId": null,
+                    "developerName": "col_tinytext",
+                    "contentType": "ContentString",
+                    "contentValue": "xxxx",
+                    "contentFormat": null,
+                    "objectData": []
+                },
+                {
+                    "typeElementPropertyId": null,
+                    "developerName": "col_text",
+                    "contentType": "ContentString",
+                    "contentValue": "xxxx",
+                    "contentFormat": null,
+                    "objectData": []
+                },
+                {
+                    "typeElementPropertyId": null,
+                    "developerName": "col_mediumtext",
+                    "contentType": "ContentString",
+                    "contentValue": "eeee",
+                    "contentFormat": null,
+                    "objectData": []
+                },
+                {
+                    "typeElementPropertyId": null,
+                    "developerName": "col_longtext",
+                    "contentType": "ContentString",
+                    "contentValue": "xxxx",
+                    "contentFormat": null,
+                    "objectData": []
+                }
+            ],
+            "isSelected": false
+        }
+    ]
+}

--- a/src/test/resources/suites/mysql/search/noresults-request.json
+++ b/src/test/resources/suites/mysql/search/noresults-request.json
@@ -1,0 +1,160 @@
+{
+    "stateId": null,
+    "token": null,
+    "typeElementBindingId": null,
+    "authorization": {
+        "users": null,
+        "groups": null,
+        "runningAuthenticationId": null,
+        "globalAuthenticationType": "PUBLIC"
+    },
+    "configurationValues": [
+        {
+            "valueElementId": null,
+            "typeElementId": null,
+            "typeElementPropertyId": null,
+            "developerName": "Password",
+            "typeElementDeveloperName": null,
+            "typeElementPropertyDeveloperName": null,
+            "contentValue": "{{password}}",
+            "contentType": "ContentPassword",
+            "objectData": null
+        },
+        {
+            "valueElementId": null,
+            "typeElementId": null,
+            "typeElementPropertyId": null,
+            "developerName": "Database Type",
+            "typeElementDeveloperName": null,
+            "typeElementPropertyDeveloperName": null,
+            "contentValue": "{{databaseType}}",
+            "contentType": "ContentString",
+            "objectData": null
+        },
+        {
+            "valueElementId": null,
+            "typeElementId": null,
+            "typeElementPropertyId": null,
+            "developerName": "Database Name",
+            "typeElementDeveloperName": null,
+            "typeElementPropertyDeveloperName": null,
+            "contentValue": "{{databaseName}}",
+            "contentType": "ContentString",
+            "objectData": null
+        },
+        {
+            "valueElementId": null,
+            "typeElementId": null,
+            "typeElementPropertyId": null,
+            "developerName": "Port",
+            "typeElementDeveloperName": null,
+            "typeElementPropertyDeveloperName": null,
+            "contentValue": "{{port}}",
+            "contentType": "ContentNumber",
+            "objectData": null
+        },
+        {
+            "valueElementId": null,
+            "typeElementId": null,
+            "typeElementPropertyId": null,
+            "developerName": "Host",
+            "typeElementDeveloperName": null,
+            "typeElementPropertyDeveloperName": null,
+            "contentValue": "{{host}}",
+            "contentType": "ContentString",
+            "objectData": null
+        },
+        {
+            "valueElementId": null,
+            "typeElementId": null,
+            "typeElementPropertyId": null,
+            "developerName": "Database Schema",
+            "typeElementDeveloperName": null,
+            "typeElementPropertyDeveloperName": null,
+            "contentValue": "{{schema}}",
+            "contentType": "ContentString",
+            "objectData": null
+        },
+        {
+            "valueElementId": null,
+            "typeElementId": null,
+            "typeElementPropertyId": null,
+            "developerName": "Username",
+            "typeElementDeveloperName": null,
+            "typeElementPropertyDeveloperName": null,
+            "contentValue": "{{userName}}",
+            "contentType": "ContentString",
+            "objectData": null
+        },
+        {
+            "valueElementId": null,
+            "typeElementId": null,
+            "typeElementPropertyId": null,
+            "developerName": "No SSL",
+            "typeElementDeveloperName": null,
+            "typeElementPropertyDeveloperName": null,
+            "contentValue": "true",
+            "contentType": null,
+            "objectData": null
+        }
+    ],
+    "command": null,
+    "culture": {
+        "id": null,
+        "developerName": null,
+        "developerSummary": null,
+        "brand": null,
+        "language": "EN",
+        "country": "USA",
+        "variant": null
+    },
+    "listFilter": {
+        "id": null,
+        "filterByProvidedObjects": false,
+        "orderByPropertyDeveloperName": "id",
+        "orderByDirectionType": "",
+        "orderBy": null,
+        "limit": 0,
+        "offset": 0,
+        "search": "noresults",
+        "searchCriteria": null,
+        "comparisonType": "OR",
+        "where": null,
+        "listFilters": null
+    },
+    "objectDataType": {
+        "typeElementId": "737809a7-5825-4b04-8d38-b271963732e5",
+        "developerName": "searchtest",
+        "properties": [
+            {
+                "developerName": "id",
+                "list": null
+            },
+            {
+                "developerName": "col_char",
+                "list": null
+            },
+            {
+                "developerName": "col_varchar",
+                "list": null
+            },
+            {
+                "developerName": "col_tinytext",
+                "list": null
+            },
+            {
+                "developerName": "col_text",
+                "list": null
+            },
+            {
+                "developerName": "col_mediumtext",
+                "list": null
+            },
+            {
+                "developerName": "col_longtext",
+                "list": null
+            }
+        ]
+    },
+    "objectData": null
+}

--- a/src/test/resources/suites/mysql/search/noresults-response.json
+++ b/src/test/resources/suites/mysql/search/noresults-response.json
@@ -1,0 +1,5 @@
+{
+    "culture": null,
+    "hasMoreResults": false,
+    "objectData": []
+}

--- a/src/test/resources/suites/mysql/search/text-request.json
+++ b/src/test/resources/suites/mysql/search/text-request.json
@@ -1,0 +1,160 @@
+{
+    "stateId": null,
+    "token": null,
+    "typeElementBindingId": null,
+    "authorization": {
+        "users": null,
+        "groups": null,
+        "runningAuthenticationId": null,
+        "globalAuthenticationType": "PUBLIC"
+    },
+    "configurationValues": [
+        {
+            "valueElementId": null,
+            "typeElementId": null,
+            "typeElementPropertyId": null,
+            "developerName": "Password",
+            "typeElementDeveloperName": null,
+            "typeElementPropertyDeveloperName": null,
+            "contentValue": "{{password}}",
+            "contentType": "ContentPassword",
+            "objectData": null
+        },
+        {
+            "valueElementId": null,
+            "typeElementId": null,
+            "typeElementPropertyId": null,
+            "developerName": "Database Type",
+            "typeElementDeveloperName": null,
+            "typeElementPropertyDeveloperName": null,
+            "contentValue": "{{databaseType}}",
+            "contentType": "ContentString",
+            "objectData": null
+        },
+        {
+            "valueElementId": null,
+            "typeElementId": null,
+            "typeElementPropertyId": null,
+            "developerName": "Database Name",
+            "typeElementDeveloperName": null,
+            "typeElementPropertyDeveloperName": null,
+            "contentValue": "{{databaseName}}",
+            "contentType": "ContentString",
+            "objectData": null
+        },
+        {
+            "valueElementId": null,
+            "typeElementId": null,
+            "typeElementPropertyId": null,
+            "developerName": "Port",
+            "typeElementDeveloperName": null,
+            "typeElementPropertyDeveloperName": null,
+            "contentValue": "{{port}}",
+            "contentType": "ContentNumber",
+            "objectData": null
+        },
+        {
+            "valueElementId": null,
+            "typeElementId": null,
+            "typeElementPropertyId": null,
+            "developerName": "Host",
+            "typeElementDeveloperName": null,
+            "typeElementPropertyDeveloperName": null,
+            "contentValue": "{{host}}",
+            "contentType": "ContentString",
+            "objectData": null
+        },
+        {
+            "valueElementId": null,
+            "typeElementId": null,
+            "typeElementPropertyId": null,
+            "developerName": "Database Schema",
+            "typeElementDeveloperName": null,
+            "typeElementPropertyDeveloperName": null,
+            "contentValue": "{{schema}}",
+            "contentType": "ContentString",
+            "objectData": null
+        },
+        {
+            "valueElementId": null,
+            "typeElementId": null,
+            "typeElementPropertyId": null,
+            "developerName": "Username",
+            "typeElementDeveloperName": null,
+            "typeElementPropertyDeveloperName": null,
+            "contentValue": "{{userName}}",
+            "contentType": "ContentString",
+            "objectData": null
+        },
+        {
+            "valueElementId": null,
+            "typeElementId": null,
+            "typeElementPropertyId": null,
+            "developerName": "No SSL",
+            "typeElementDeveloperName": null,
+            "typeElementPropertyDeveloperName": null,
+            "contentValue": "true",
+            "contentType": null,
+            "objectData": null
+        }
+    ],
+    "command": null,
+    "culture": {
+        "id": null,
+        "developerName": null,
+        "developerSummary": null,
+        "brand": null,
+        "language": "EN",
+        "country": "USA",
+        "variant": null
+    },
+    "listFilter": {
+        "id": null,
+        "filterByProvidedObjects": false,
+        "orderByPropertyDeveloperName": "id",
+        "orderByDirectionType": "",
+        "orderBy": null,
+        "limit": 0,
+        "offset": 0,
+        "search": "dd",
+        "searchCriteria": null,
+        "comparisonType": "OR",
+        "where": null,
+        "listFilters": null
+    },
+    "objectDataType": {
+        "typeElementId": "737809a7-5825-4b04-8d38-b271963732e5",
+        "developerName": "searchtest",
+        "properties": [
+            {
+                "developerName": "id",
+                "list": null
+            },
+            {
+                "developerName": "col_char",
+                "list": null
+            },
+            {
+                "developerName": "col_varchar",
+                "list": null
+            },
+            {
+                "developerName": "col_tinytext",
+                "list": null
+            },
+            {
+                "developerName": "col_text",
+                "list": null
+            },
+            {
+                "developerName": "col_mediumtext",
+                "list": null
+            },
+            {
+                "developerName": "col_longtext",
+                "list": null
+            }
+        ]
+    },
+    "objectData": null
+}

--- a/src/test/resources/suites/mysql/search/text-response.json
+++ b/src/test/resources/suites/mysql/search/text-response.json
@@ -1,0 +1,72 @@
+{
+    "culture": null,
+    "hasMoreResults": false,
+    "objectData": [
+        {
+            "internalId": null,
+            "externalId": "eyJpZCI6IjQifQ==",
+            "developerName": "searchtest",
+            "typeElementId": null,
+            "order": 0,
+            "properties": [
+                {
+                    "typeElementPropertyId": null,
+                    "developerName": "id",
+                    "contentType": "ContentNumber",
+                    "contentValue": "4",
+                    "contentFormat": null,
+                    "objectData": []
+                },
+                {
+                    "typeElementPropertyId": null,
+                    "developerName": "col_char",
+                    "contentType": "ContentString",
+                    "contentValue": "xxxx",
+                    "contentFormat": null,
+                    "objectData": []
+                },
+                {
+                    "typeElementPropertyId": null,
+                    "developerName": "col_varchar",
+                    "contentType": "ContentString",
+                    "contentValue": "xxxx",
+                    "contentFormat": null,
+                    "objectData": []
+                },
+                {
+                    "typeElementPropertyId": null,
+                    "developerName": "col_tinytext",
+                    "contentType": "ContentString",
+                    "contentValue": "xxxx",
+                    "contentFormat": null,
+                    "objectData": []
+                },
+                {
+                    "typeElementPropertyId": null,
+                    "developerName": "col_text",
+                    "contentType": "ContentString",
+                    "contentValue": "dddd",
+                    "contentFormat": null,
+                    "objectData": []
+                },
+                {
+                    "typeElementPropertyId": null,
+                    "developerName": "col_mediumtext",
+                    "contentType": "ContentString",
+                    "contentValue": "xxxx",
+                    "contentFormat": null,
+                    "objectData": []
+                },
+                {
+                    "typeElementPropertyId": null,
+                    "developerName": "col_longtext",
+                    "contentType": "ContentString",
+                    "contentValue": "xxxx",
+                    "contentFormat": null,
+                    "objectData": []
+                }
+            ],
+            "isSelected": false
+        }
+    ]
+}

--- a/src/test/resources/suites/mysql/search/tinytext-request.json
+++ b/src/test/resources/suites/mysql/search/tinytext-request.json
@@ -1,0 +1,160 @@
+{
+    "stateId": null,
+    "token": null,
+    "typeElementBindingId": null,
+    "authorization": {
+        "users": null,
+        "groups": null,
+        "runningAuthenticationId": null,
+        "globalAuthenticationType": "PUBLIC"
+    },
+    "configurationValues": [
+        {
+            "valueElementId": null,
+            "typeElementId": null,
+            "typeElementPropertyId": null,
+            "developerName": "Password",
+            "typeElementDeveloperName": null,
+            "typeElementPropertyDeveloperName": null,
+            "contentValue": "{{password}}",
+            "contentType": "ContentPassword",
+            "objectData": null
+        },
+        {
+            "valueElementId": null,
+            "typeElementId": null,
+            "typeElementPropertyId": null,
+            "developerName": "Database Type",
+            "typeElementDeveloperName": null,
+            "typeElementPropertyDeveloperName": null,
+            "contentValue": "{{databaseType}}",
+            "contentType": "ContentString",
+            "objectData": null
+        },
+        {
+            "valueElementId": null,
+            "typeElementId": null,
+            "typeElementPropertyId": null,
+            "developerName": "Database Name",
+            "typeElementDeveloperName": null,
+            "typeElementPropertyDeveloperName": null,
+            "contentValue": "{{databaseName}}",
+            "contentType": "ContentString",
+            "objectData": null
+        },
+        {
+            "valueElementId": null,
+            "typeElementId": null,
+            "typeElementPropertyId": null,
+            "developerName": "Port",
+            "typeElementDeveloperName": null,
+            "typeElementPropertyDeveloperName": null,
+            "contentValue": "{{port}}",
+            "contentType": "ContentNumber",
+            "objectData": null
+        },
+        {
+            "valueElementId": null,
+            "typeElementId": null,
+            "typeElementPropertyId": null,
+            "developerName": "Host",
+            "typeElementDeveloperName": null,
+            "typeElementPropertyDeveloperName": null,
+            "contentValue": "{{host}}",
+            "contentType": "ContentString",
+            "objectData": null
+        },
+        {
+            "valueElementId": null,
+            "typeElementId": null,
+            "typeElementPropertyId": null,
+            "developerName": "Database Schema",
+            "typeElementDeveloperName": null,
+            "typeElementPropertyDeveloperName": null,
+            "contentValue": "{{schema}}",
+            "contentType": "ContentString",
+            "objectData": null
+        },
+        {
+            "valueElementId": null,
+            "typeElementId": null,
+            "typeElementPropertyId": null,
+            "developerName": "Username",
+            "typeElementDeveloperName": null,
+            "typeElementPropertyDeveloperName": null,
+            "contentValue": "{{userName}}",
+            "contentType": "ContentString",
+            "objectData": null
+        },
+        {
+            "valueElementId": null,
+            "typeElementId": null,
+            "typeElementPropertyId": null,
+            "developerName": "No SSL",
+            "typeElementDeveloperName": null,
+            "typeElementPropertyDeveloperName": null,
+            "contentValue": "true",
+            "contentType": null,
+            "objectData": null
+        }
+    ],
+    "command": null,
+    "culture": {
+        "id": null,
+        "developerName": null,
+        "developerSummary": null,
+        "brand": null,
+        "language": "EN",
+        "country": "USA",
+        "variant": null
+    },
+    "listFilter": {
+        "id": null,
+        "filterByProvidedObjects": false,
+        "orderByPropertyDeveloperName": "id",
+        "orderByDirectionType": "",
+        "orderBy": null,
+        "limit": 0,
+        "offset": 0,
+        "search": "cc",
+        "searchCriteria": null,
+        "comparisonType": "OR",
+        "where": null,
+        "listFilters": null
+    },
+    "objectDataType": {
+        "typeElementId": "737809a7-5825-4b04-8d38-b271963732e5",
+        "developerName": "searchtest",
+        "properties": [
+            {
+                "developerName": "id",
+                "list": null
+            },
+            {
+                "developerName": "col_char",
+                "list": null
+            },
+            {
+                "developerName": "col_varchar",
+                "list": null
+            },
+            {
+                "developerName": "col_tinytext",
+                "list": null
+            },
+            {
+                "developerName": "col_text",
+                "list": null
+            },
+            {
+                "developerName": "col_mediumtext",
+                "list": null
+            },
+            {
+                "developerName": "col_longtext",
+                "list": null
+            }
+        ]
+    },
+    "objectData": null
+}

--- a/src/test/resources/suites/mysql/search/tinytext-response.json
+++ b/src/test/resources/suites/mysql/search/tinytext-response.json
@@ -1,0 +1,72 @@
+{
+    "culture": null,
+    "hasMoreResults": false,
+    "objectData": [
+        {
+            "internalId": null,
+            "externalId": "eyJpZCI6IjMifQ==",
+            "developerName": "searchtest",
+            "typeElementId": null,
+            "order": 0,
+            "properties": [
+                {
+                    "typeElementPropertyId": null,
+                    "developerName": "id",
+                    "contentType": "ContentNumber",
+                    "contentValue": "3",
+                    "contentFormat": null,
+                    "objectData": []
+                },
+                {
+                    "typeElementPropertyId": null,
+                    "developerName": "col_char",
+                    "contentType": "ContentString",
+                    "contentValue": "xxxx",
+                    "contentFormat": null,
+                    "objectData": []
+                },
+                {
+                    "typeElementPropertyId": null,
+                    "developerName": "col_varchar",
+                    "contentType": "ContentString",
+                    "contentValue": "xxxx",
+                    "contentFormat": null,
+                    "objectData": []
+                },
+                {
+                    "typeElementPropertyId": null,
+                    "developerName": "col_tinytext",
+                    "contentType": "ContentString",
+                    "contentValue": "cccc",
+                    "contentFormat": null,
+                    "objectData": []
+                },
+                {
+                    "typeElementPropertyId": null,
+                    "developerName": "col_text",
+                    "contentType": "ContentString",
+                    "contentValue": "xxxx",
+                    "contentFormat": null,
+                    "objectData": []
+                },
+                {
+                    "typeElementPropertyId": null,
+                    "developerName": "col_mediumtext",
+                    "contentType": "ContentString",
+                    "contentValue": "xxxx",
+                    "contentFormat": null,
+                    "objectData": []
+                },
+                {
+                    "typeElementPropertyId": null,
+                    "developerName": "col_longtext",
+                    "contentType": "ContentString",
+                    "contentValue": "xxxx",
+                    "contentFormat": null,
+                    "objectData": []
+                }
+            ],
+            "isSelected": false
+        }
+    ]
+}

--- a/src/test/resources/suites/mysql/search/varchar-request.json
+++ b/src/test/resources/suites/mysql/search/varchar-request.json
@@ -1,0 +1,160 @@
+{
+    "stateId": null,
+    "token": null,
+    "typeElementBindingId": null,
+    "authorization": {
+        "users": null,
+        "groups": null,
+        "runningAuthenticationId": null,
+        "globalAuthenticationType": "PUBLIC"
+    },
+    "configurationValues": [
+        {
+            "valueElementId": null,
+            "typeElementId": null,
+            "typeElementPropertyId": null,
+            "developerName": "Password",
+            "typeElementDeveloperName": null,
+            "typeElementPropertyDeveloperName": null,
+            "contentValue": "{{password}}",
+            "contentType": "ContentPassword",
+            "objectData": null
+        },
+        {
+            "valueElementId": null,
+            "typeElementId": null,
+            "typeElementPropertyId": null,
+            "developerName": "Database Type",
+            "typeElementDeveloperName": null,
+            "typeElementPropertyDeveloperName": null,
+            "contentValue": "{{databaseType}}",
+            "contentType": "ContentString",
+            "objectData": null
+        },
+        {
+            "valueElementId": null,
+            "typeElementId": null,
+            "typeElementPropertyId": null,
+            "developerName": "Database Name",
+            "typeElementDeveloperName": null,
+            "typeElementPropertyDeveloperName": null,
+            "contentValue": "{{databaseName}}",
+            "contentType": "ContentString",
+            "objectData": null
+        },
+        {
+            "valueElementId": null,
+            "typeElementId": null,
+            "typeElementPropertyId": null,
+            "developerName": "Port",
+            "typeElementDeveloperName": null,
+            "typeElementPropertyDeveloperName": null,
+            "contentValue": "{{port}}",
+            "contentType": "ContentNumber",
+            "objectData": null
+        },
+        {
+            "valueElementId": null,
+            "typeElementId": null,
+            "typeElementPropertyId": null,
+            "developerName": "Host",
+            "typeElementDeveloperName": null,
+            "typeElementPropertyDeveloperName": null,
+            "contentValue": "{{host}}",
+            "contentType": "ContentString",
+            "objectData": null
+        },
+        {
+            "valueElementId": null,
+            "typeElementId": null,
+            "typeElementPropertyId": null,
+            "developerName": "Database Schema",
+            "typeElementDeveloperName": null,
+            "typeElementPropertyDeveloperName": null,
+            "contentValue": "{{schema}}",
+            "contentType": "ContentString",
+            "objectData": null
+        },
+        {
+            "valueElementId": null,
+            "typeElementId": null,
+            "typeElementPropertyId": null,
+            "developerName": "Username",
+            "typeElementDeveloperName": null,
+            "typeElementPropertyDeveloperName": null,
+            "contentValue": "{{userName}}",
+            "contentType": "ContentString",
+            "objectData": null
+        },
+        {
+            "valueElementId": null,
+            "typeElementId": null,
+            "typeElementPropertyId": null,
+            "developerName": "No SSL",
+            "typeElementDeveloperName": null,
+            "typeElementPropertyDeveloperName": null,
+            "contentValue": "true",
+            "contentType": null,
+            "objectData": null
+        }
+    ],
+    "command": null,
+    "culture": {
+        "id": null,
+        "developerName": null,
+        "developerSummary": null,
+        "brand": null,
+        "language": "EN",
+        "country": "USA",
+        "variant": null
+    },
+    "listFilter": {
+        "id": null,
+        "filterByProvidedObjects": false,
+        "orderByPropertyDeveloperName": "id",
+        "orderByDirectionType": "",
+        "orderBy": null,
+        "limit": 0,
+        "offset": 0,
+        "search": "bb",
+        "searchCriteria": null,
+        "comparisonType": "OR",
+        "where": null,
+        "listFilters": null
+    },
+    "objectDataType": {
+        "typeElementId": "737809a7-5825-4b04-8d38-b271963732e5",
+        "developerName": "searchtest",
+        "properties": [
+            {
+                "developerName": "id",
+                "list": null
+            },
+            {
+                "developerName": "col_char",
+                "list": null
+            },
+            {
+                "developerName": "col_varchar",
+                "list": null
+            },
+            {
+                "developerName": "col_tinytext",
+                "list": null
+            },
+            {
+                "developerName": "col_text",
+                "list": null
+            },
+            {
+                "developerName": "col_mediumtext",
+                "list": null
+            },
+            {
+                "developerName": "col_longtext",
+                "list": null
+            }
+        ]
+    },
+    "objectData": null
+}

--- a/src/test/resources/suites/mysql/search/varchar-response.json
+++ b/src/test/resources/suites/mysql/search/varchar-response.json
@@ -1,0 +1,72 @@
+{
+    "culture": null,
+    "hasMoreResults": false,
+    "objectData": [
+        {
+            "internalId": null,
+            "externalId": "eyJpZCI6IjIifQ==",
+            "developerName": "searchtest",
+            "typeElementId": null,
+            "order": 0,
+            "properties": [
+                {
+                    "typeElementPropertyId": null,
+                    "developerName": "id",
+                    "contentType": "ContentNumber",
+                    "contentValue": "2",
+                    "contentFormat": null,
+                    "objectData": []
+                },
+                {
+                    "typeElementPropertyId": null,
+                    "developerName": "col_char",
+                    "contentType": "ContentString",
+                    "contentValue": "xxxx",
+                    "contentFormat": null,
+                    "objectData": []
+                },
+                {
+                    "typeElementPropertyId": null,
+                    "developerName": "col_varchar",
+                    "contentType": "ContentString",
+                    "contentValue": "bbbb",
+                    "contentFormat": null,
+                    "objectData": []
+                },
+                {
+                    "typeElementPropertyId": null,
+                    "developerName": "col_tinytext",
+                    "contentType": "ContentString",
+                    "contentValue": "xxxx",
+                    "contentFormat": null,
+                    "objectData": []
+                },
+                {
+                    "typeElementPropertyId": null,
+                    "developerName": "col_text",
+                    "contentType": "ContentString",
+                    "contentValue": "xxxx",
+                    "contentFormat": null,
+                    "objectData": []
+                },
+                {
+                    "typeElementPropertyId": null,
+                    "developerName": "col_mediumtext",
+                    "contentType": "ContentString",
+                    "contentValue": "xxxx",
+                    "contentFormat": null,
+                    "objectData": []
+                },
+                {
+                    "typeElementPropertyId": null,
+                    "developerName": "col_longtext",
+                    "contentType": "ContentString",
+                    "contentValue": "xxxx",
+                    "contentFormat": null,
+                    "objectData": []
+                }
+            ],
+            "isSelected": false
+        }
+    ]
+}

--- a/src/test/resources/suites/mysql/search/xxxx-request.json
+++ b/src/test/resources/suites/mysql/search/xxxx-request.json
@@ -1,0 +1,160 @@
+{
+    "stateId": null,
+    "token": null,
+    "typeElementBindingId": null,
+    "authorization": {
+        "users": null,
+        "groups": null,
+        "runningAuthenticationId": null,
+        "globalAuthenticationType": "PUBLIC"
+    },
+    "configurationValues": [
+        {
+            "valueElementId": null,
+            "typeElementId": null,
+            "typeElementPropertyId": null,
+            "developerName": "Password",
+            "typeElementDeveloperName": null,
+            "typeElementPropertyDeveloperName": null,
+            "contentValue": "{{password}}",
+            "contentType": "ContentPassword",
+            "objectData": null
+        },
+        {
+            "valueElementId": null,
+            "typeElementId": null,
+            "typeElementPropertyId": null,
+            "developerName": "Database Type",
+            "typeElementDeveloperName": null,
+            "typeElementPropertyDeveloperName": null,
+            "contentValue": "{{databaseType}}",
+            "contentType": "ContentString",
+            "objectData": null
+        },
+        {
+            "valueElementId": null,
+            "typeElementId": null,
+            "typeElementPropertyId": null,
+            "developerName": "Database Name",
+            "typeElementDeveloperName": null,
+            "typeElementPropertyDeveloperName": null,
+            "contentValue": "{{databaseName}}",
+            "contentType": "ContentString",
+            "objectData": null
+        },
+        {
+            "valueElementId": null,
+            "typeElementId": null,
+            "typeElementPropertyId": null,
+            "developerName": "Port",
+            "typeElementDeveloperName": null,
+            "typeElementPropertyDeveloperName": null,
+            "contentValue": "{{port}}",
+            "contentType": "ContentNumber",
+            "objectData": null
+        },
+        {
+            "valueElementId": null,
+            "typeElementId": null,
+            "typeElementPropertyId": null,
+            "developerName": "Host",
+            "typeElementDeveloperName": null,
+            "typeElementPropertyDeveloperName": null,
+            "contentValue": "{{host}}",
+            "contentType": "ContentString",
+            "objectData": null
+        },
+        {
+            "valueElementId": null,
+            "typeElementId": null,
+            "typeElementPropertyId": null,
+            "developerName": "Database Schema",
+            "typeElementDeveloperName": null,
+            "typeElementPropertyDeveloperName": null,
+            "contentValue": "{{schema}}",
+            "contentType": "ContentString",
+            "objectData": null
+        },
+        {
+            "valueElementId": null,
+            "typeElementId": null,
+            "typeElementPropertyId": null,
+            "developerName": "Username",
+            "typeElementDeveloperName": null,
+            "typeElementPropertyDeveloperName": null,
+            "contentValue": "{{userName}}",
+            "contentType": "ContentString",
+            "objectData": null
+        },
+        {
+            "valueElementId": null,
+            "typeElementId": null,
+            "typeElementPropertyId": null,
+            "developerName": "No SSL",
+            "typeElementDeveloperName": null,
+            "typeElementPropertyDeveloperName": null,
+            "contentValue": "true",
+            "contentType": null,
+            "objectData": null
+        }
+    ],
+    "command": null,
+    "culture": {
+        "id": null,
+        "developerName": null,
+        "developerSummary": null,
+        "brand": null,
+        "language": "EN",
+        "country": "USA",
+        "variant": null
+    },
+    "listFilter": {
+        "id": null,
+        "filterByProvidedObjects": false,
+        "orderByPropertyDeveloperName": "id",
+        "orderByDirectionType": "",
+        "orderBy": null,
+        "limit": 0,
+        "offset": 0,
+        "search": "xx",
+        "searchCriteria": null,
+        "comparisonType": "OR",
+        "where": null,
+        "listFilters": null
+    },
+    "objectDataType": {
+        "typeElementId": "737809a7-5825-4b04-8d38-b271963732e5",
+        "developerName": "searchtest",
+        "properties": [
+            {
+                "developerName": "id",
+                "list": null
+            },
+            {
+                "developerName": "col_char",
+                "list": null
+            },
+            {
+                "developerName": "col_varchar",
+                "list": null
+            },
+            {
+                "developerName": "col_tinytext",
+                "list": null
+            },
+            {
+                "developerName": "col_text",
+                "list": null
+            },
+            {
+                "developerName": "col_mediumtext",
+                "list": null
+            },
+            {
+                "developerName": "col_longtext",
+                "list": null
+            }
+        ]
+    },
+    "objectData": null
+}

--- a/src/test/resources/suites/mysql/search/xxxx-response.json
+++ b/src/test/resources/suites/mysql/search/xxxx-response.json
@@ -1,0 +1,402 @@
+{
+    "culture": null,
+    "hasMoreResults": false,
+    "objectData": [
+        {
+            "internalId": null,
+            "externalId": "eyJpZCI6IjEifQ==",
+            "developerName": "searchtest",
+            "typeElementId": null,
+            "order": 0,
+            "properties": [
+                {
+                    "typeElementPropertyId": null,
+                    "developerName": "id",
+                    "contentType": "ContentNumber",
+                    "contentValue": "1",
+                    "contentFormat": null,
+                    "objectData": []
+                },
+                {
+                    "typeElementPropertyId": null,
+                    "developerName": "col_char",
+                    "contentType": "ContentString",
+                    "contentValue": "aaaa",
+                    "contentFormat": null,
+                    "objectData": []
+                },
+                {
+                    "typeElementPropertyId": null,
+                    "developerName": "col_varchar",
+                    "contentType": "ContentString",
+                    "contentValue": "xxxx",
+                    "contentFormat": null,
+                    "objectData": []
+                },
+                {
+                    "typeElementPropertyId": null,
+                    "developerName": "col_tinytext",
+                    "contentType": "ContentString",
+                    "contentValue": "xxxx",
+                    "contentFormat": null,
+                    "objectData": []
+                },
+                {
+                    "typeElementPropertyId": null,
+                    "developerName": "col_text",
+                    "contentType": "ContentString",
+                    "contentValue": "xxxx",
+                    "contentFormat": null,
+                    "objectData": []
+                },
+                {
+                    "typeElementPropertyId": null,
+                    "developerName": "col_mediumtext",
+                    "contentType": "ContentString",
+                    "contentValue": "xxxx",
+                    "contentFormat": null,
+                    "objectData": []
+                },
+                {
+                    "typeElementPropertyId": null,
+                    "developerName": "col_longtext",
+                    "contentType": "ContentString",
+                    "contentValue": "xxxx",
+                    "contentFormat": null,
+                    "objectData": []
+                }
+            ],
+            "isSelected": false
+        },
+        {
+            "internalId": null,
+            "externalId": "eyJpZCI6IjIifQ==",
+            "developerName": "searchtest",
+            "typeElementId": null,
+            "order": 0,
+            "properties": [
+                {
+                    "typeElementPropertyId": null,
+                    "developerName": "id",
+                    "contentType": "ContentNumber",
+                    "contentValue": "2",
+                    "contentFormat": null,
+                    "objectData": []
+                },
+                {
+                    "typeElementPropertyId": null,
+                    "developerName": "col_char",
+                    "contentType": "ContentString",
+                    "contentValue": "xxxx",
+                    "contentFormat": null,
+                    "objectData": []
+                },
+                {
+                    "typeElementPropertyId": null,
+                    "developerName": "col_varchar",
+                    "contentType": "ContentString",
+                    "contentValue": "bbbb",
+                    "contentFormat": null,
+                    "objectData": []
+                },
+                {
+                    "typeElementPropertyId": null,
+                    "developerName": "col_tinytext",
+                    "contentType": "ContentString",
+                    "contentValue": "xxxx",
+                    "contentFormat": null,
+                    "objectData": []
+                },
+                {
+                    "typeElementPropertyId": null,
+                    "developerName": "col_text",
+                    "contentType": "ContentString",
+                    "contentValue": "xxxx",
+                    "contentFormat": null,
+                    "objectData": []
+                },
+                {
+                    "typeElementPropertyId": null,
+                    "developerName": "col_mediumtext",
+                    "contentType": "ContentString",
+                    "contentValue": "xxxx",
+                    "contentFormat": null,
+                    "objectData": []
+                },
+                {
+                    "typeElementPropertyId": null,
+                    "developerName": "col_longtext",
+                    "contentType": "ContentString",
+                    "contentValue": "xxxx",
+                    "contentFormat": null,
+                    "objectData": []
+                }
+            ],
+            "isSelected": false
+        },
+        {
+            "internalId": null,
+            "externalId": "eyJpZCI6IjMifQ==",
+            "developerName": "searchtest",
+            "typeElementId": null,
+            "order": 0,
+            "properties": [
+                {
+                    "typeElementPropertyId": null,
+                    "developerName": "id",
+                    "contentType": "ContentNumber",
+                    "contentValue": "3",
+                    "contentFormat": null,
+                    "objectData": []
+                },
+                {
+                    "typeElementPropertyId": null,
+                    "developerName": "col_char",
+                    "contentType": "ContentString",
+                    "contentValue": "xxxx",
+                    "contentFormat": null,
+                    "objectData": []
+                },
+                {
+                    "typeElementPropertyId": null,
+                    "developerName": "col_varchar",
+                    "contentType": "ContentString",
+                    "contentValue": "xxxx",
+                    "contentFormat": null,
+                    "objectData": []
+                },
+                {
+                    "typeElementPropertyId": null,
+                    "developerName": "col_tinytext",
+                    "contentType": "ContentString",
+                    "contentValue": "cccc",
+                    "contentFormat": null,
+                    "objectData": []
+                },
+                {
+                    "typeElementPropertyId": null,
+                    "developerName": "col_text",
+                    "contentType": "ContentString",
+                    "contentValue": "xxxx",
+                    "contentFormat": null,
+                    "objectData": []
+                },
+                {
+                    "typeElementPropertyId": null,
+                    "developerName": "col_mediumtext",
+                    "contentType": "ContentString",
+                    "contentValue": "xxxx",
+                    "contentFormat": null,
+                    "objectData": []
+                },
+                {
+                    "typeElementPropertyId": null,
+                    "developerName": "col_longtext",
+                    "contentType": "ContentString",
+                    "contentValue": "xxxx",
+                    "contentFormat": null,
+                    "objectData": []
+                }
+            ],
+            "isSelected": false
+        },
+        {
+            "internalId": null,
+            "externalId": "eyJpZCI6IjQifQ==",
+            "developerName": "searchtest",
+            "typeElementId": null,
+            "order": 0,
+            "properties": [
+                {
+                    "typeElementPropertyId": null,
+                    "developerName": "id",
+                    "contentType": "ContentNumber",
+                    "contentValue": "4",
+                    "contentFormat": null,
+                    "objectData": []
+                },
+                {
+                    "typeElementPropertyId": null,
+                    "developerName": "col_char",
+                    "contentType": "ContentString",
+                    "contentValue": "xxxx",
+                    "contentFormat": null,
+                    "objectData": []
+                },
+                {
+                    "typeElementPropertyId": null,
+                    "developerName": "col_varchar",
+                    "contentType": "ContentString",
+                    "contentValue": "xxxx",
+                    "contentFormat": null,
+                    "objectData": []
+                },
+                {
+                    "typeElementPropertyId": null,
+                    "developerName": "col_tinytext",
+                    "contentType": "ContentString",
+                    "contentValue": "xxxx",
+                    "contentFormat": null,
+                    "objectData": []
+                },
+                {
+                    "typeElementPropertyId": null,
+                    "developerName": "col_text",
+                    "contentType": "ContentString",
+                    "contentValue": "dddd",
+                    "contentFormat": null,
+                    "objectData": []
+                },
+                {
+                    "typeElementPropertyId": null,
+                    "developerName": "col_mediumtext",
+                    "contentType": "ContentString",
+                    "contentValue": "xxxx",
+                    "contentFormat": null,
+                    "objectData": []
+                },
+                {
+                    "typeElementPropertyId": null,
+                    "developerName": "col_longtext",
+                    "contentType": "ContentString",
+                    "contentValue": "xxxx",
+                    "contentFormat": null,
+                    "objectData": []
+                }
+            ],
+            "isSelected": false
+        },
+        {
+            "internalId": null,
+            "externalId": "eyJpZCI6IjUifQ==",
+            "developerName": "searchtest",
+            "typeElementId": null,
+            "order": 0,
+            "properties": [
+                {
+                    "typeElementPropertyId": null,
+                    "developerName": "id",
+                    "contentType": "ContentNumber",
+                    "contentValue": "5",
+                    "contentFormat": null,
+                    "objectData": []
+                },
+                {
+                    "typeElementPropertyId": null,
+                    "developerName": "col_char",
+                    "contentType": "ContentString",
+                    "contentValue": "xxxx",
+                    "contentFormat": null,
+                    "objectData": []
+                },
+                {
+                    "typeElementPropertyId": null,
+                    "developerName": "col_varchar",
+                    "contentType": "ContentString",
+                    "contentValue": "xxxx",
+                    "contentFormat": null,
+                    "objectData": []
+                },
+                {
+                    "typeElementPropertyId": null,
+                    "developerName": "col_tinytext",
+                    "contentType": "ContentString",
+                    "contentValue": "xxxx",
+                    "contentFormat": null,
+                    "objectData": []
+                },
+                {
+                    "typeElementPropertyId": null,
+                    "developerName": "col_text",
+                    "contentType": "ContentString",
+                    "contentValue": "xxxx",
+                    "contentFormat": null,
+                    "objectData": []
+                },
+                {
+                    "typeElementPropertyId": null,
+                    "developerName": "col_mediumtext",
+                    "contentType": "ContentString",
+                    "contentValue": "eeee",
+                    "contentFormat": null,
+                    "objectData": []
+                },
+                {
+                    "typeElementPropertyId": null,
+                    "developerName": "col_longtext",
+                    "contentType": "ContentString",
+                    "contentValue": "xxxx",
+                    "contentFormat": null,
+                    "objectData": []
+                }
+            ],
+            "isSelected": false
+        },
+        {
+            "internalId": null,
+            "externalId": "eyJpZCI6IjYifQ==",
+            "developerName": "searchtest",
+            "typeElementId": null,
+            "order": 0,
+            "properties": [
+                {
+                    "typeElementPropertyId": null,
+                    "developerName": "id",
+                    "contentType": "ContentNumber",
+                    "contentValue": "6",
+                    "contentFormat": null,
+                    "objectData": []
+                },
+                {
+                    "typeElementPropertyId": null,
+                    "developerName": "col_char",
+                    "contentType": "ContentString",
+                    "contentValue": "xxxx",
+                    "contentFormat": null,
+                    "objectData": []
+                },
+                {
+                    "typeElementPropertyId": null,
+                    "developerName": "col_varchar",
+                    "contentType": "ContentString",
+                    "contentValue": "xxxx",
+                    "contentFormat": null,
+                    "objectData": []
+                },
+                {
+                    "typeElementPropertyId": null,
+                    "developerName": "col_tinytext",
+                    "contentType": "ContentString",
+                    "contentValue": "xxxx",
+                    "contentFormat": null,
+                    "objectData": []
+                },
+                {
+                    "typeElementPropertyId": null,
+                    "developerName": "col_text",
+                    "contentType": "ContentString",
+                    "contentValue": "xxxx",
+                    "contentFormat": null,
+                    "objectData": []
+                },
+                {
+                    "typeElementPropertyId": null,
+                    "developerName": "col_mediumtext",
+                    "contentType": "ContentString",
+                    "contentValue": "xxxx",
+                    "contentFormat": null,
+                    "objectData": []
+                },
+                {
+                    "typeElementPropertyId": null,
+                    "developerName": "col_longtext",
+                    "contentType": "ContentString",
+                    "contentValue": "ffff",
+                    "contentFormat": null,
+                    "objectData": []
+                }
+            ],
+            "isSelected": false
+        }
+    ]
+}

--- a/src/test/resources/suites/postgresql/search/allresults-request.json
+++ b/src/test/resources/suites/postgresql/search/allresults-request.json
@@ -1,0 +1,148 @@
+{
+    "stateId": null,
+    "token": null,
+    "typeElementBindingId": null,
+    "authorization": {
+        "users": null,
+        "groups": null,
+        "runningAuthenticationId": null,
+        "globalAuthenticationType": "PUBLIC"
+    },
+    "configurationValues": [
+        {
+            "valueElementId": null,
+            "typeElementId": null,
+            "typeElementPropertyId": null,
+            "developerName": "Password",
+            "typeElementDeveloperName": null,
+            "typeElementPropertyDeveloperName": null,
+            "contentValue": "{{password}}",
+            "contentType": "ContentPassword",
+            "objectData": null
+        },
+        {
+            "valueElementId": null,
+            "typeElementId": null,
+            "typeElementPropertyId": null,
+            "developerName": "Database Type",
+            "typeElementDeveloperName": null,
+            "typeElementPropertyDeveloperName": null,
+            "contentValue": "{{databaseType}}",
+            "contentType": "ContentString",
+            "objectData": null
+        },
+        {
+            "valueElementId": null,
+            "typeElementId": null,
+            "typeElementPropertyId": null,
+            "developerName": "Database Name",
+            "typeElementDeveloperName": null,
+            "typeElementPropertyDeveloperName": null,
+            "contentValue": "{{databaseName}}",
+            "contentType": "ContentString",
+            "objectData": null
+        },
+        {
+            "valueElementId": null,
+            "typeElementId": null,
+            "typeElementPropertyId": null,
+            "developerName": "Port",
+            "typeElementDeveloperName": null,
+            "typeElementPropertyDeveloperName": null,
+            "contentValue": "{{port}}",
+            "contentType": "ContentNumber",
+            "objectData": null
+        },
+        {
+            "valueElementId": null,
+            "typeElementId": null,
+            "typeElementPropertyId": null,
+            "developerName": "Host",
+            "typeElementDeveloperName": null,
+            "typeElementPropertyDeveloperName": null,
+            "contentValue": "{{host}}",
+            "contentType": "ContentString",
+            "objectData": null
+        },
+        {
+            "valueElementId": null,
+            "typeElementId": null,
+            "typeElementPropertyId": null,
+            "developerName": "Database Schema",
+            "typeElementDeveloperName": null,
+            "typeElementPropertyDeveloperName": null,
+            "contentValue": "{{schema}}",
+            "contentType": "ContentString",
+            "objectData": null
+        },
+        {
+            "valueElementId": null,
+            "typeElementId": null,
+            "typeElementPropertyId": null,
+            "developerName": "Username",
+            "typeElementDeveloperName": null,
+            "typeElementPropertyDeveloperName": null,
+            "contentValue": "{{userName}}",
+            "contentType": "ContentString",
+            "objectData": null
+        },
+        {
+            "valueElementId": null,
+            "typeElementId": null,
+            "typeElementPropertyId": null,
+            "developerName": "No SSL",
+            "typeElementDeveloperName": null,
+            "typeElementPropertyDeveloperName": null,
+            "contentValue": "true",
+            "contentType": null,
+            "objectData": null
+        }
+    ],
+    "command": null,
+    "culture": {
+        "id": null,
+        "developerName": null,
+        "developerSummary": null,
+        "brand": null,
+        "language": "EN",
+        "country": "USA",
+        "variant": null
+    },
+    "listFilter": {
+        "id": null,
+        "filterByProvidedObjects": false,
+        "orderByPropertyDeveloperName": "id",
+        "orderByDirectionType": "",
+        "orderBy": null,
+        "limit": 0,
+        "offset": 0,
+        "search": null,
+        "searchCriteria": null,
+        "comparisonType": "OR",
+        "where": null,
+        "listFilters": null
+    },
+    "objectDataType": {
+        "typeElementId": "737809a7-5825-4b04-8d38-b271963732e5",
+        "developerName": "searchtest",
+        "properties": [
+            {
+                "developerName": "id",
+                "list": null
+            },
+            {
+                "developerName": "col_char",
+                "list": null
+            },
+            {
+                "developerName": "col_varchar",
+                "list": null
+            },
+            {
+                "developerName": "col_text",
+                "list": null
+            }
+        ]
+    },
+    "objectData": null
+}

--- a/src/test/resources/suites/postgresql/search/allresults-response.json
+++ b/src/test/resources/suites/postgresql/search/allresults-response.json
@@ -1,0 +1,174 @@
+{
+    "culture": null,
+    "hasMoreResults": false,
+    "objectData": [
+        {
+            "internalId": null,
+            "externalId": "eyJpZCI6IjEifQ==",
+            "developerName": "searchtest",
+            "typeElementId": null,
+            "order": 0,
+            "properties": [
+                {
+                    "typeElementPropertyId": null,
+                    "developerName": "id",
+                    "contentType": "ContentNumber",
+                    "contentValue": "1",
+                    "contentFormat": null,
+                    "objectData": []
+                },
+                {
+                    "typeElementPropertyId": null,
+                    "developerName": "col_char",
+                    "contentType": "ContentString",
+                    "contentValue": "aaaa",
+                    "contentFormat": null,
+                    "objectData": []
+                },
+                {
+                    "typeElementPropertyId": null,
+                    "developerName": "col_varchar",
+                    "contentType": "ContentString",
+                    "contentValue": "xxxx",
+                    "contentFormat": null,
+                    "objectData": []
+                },
+                {
+                    "typeElementPropertyId": null,
+                    "developerName": "col_text",
+                    "contentType": "ContentString",
+                    "contentValue": "xxxx",
+                    "contentFormat": null,
+                    "objectData": []
+                }
+            ],
+            "isSelected": false
+        },
+        {
+            "internalId": null,
+            "externalId": "eyJpZCI6IjIifQ==",
+            "developerName": "searchtest",
+            "typeElementId": null,
+            "order": 0,
+            "properties": [
+                {
+                    "typeElementPropertyId": null,
+                    "developerName": "id",
+                    "contentType": "ContentNumber",
+                    "contentValue": "2",
+                    "contentFormat": null,
+                    "objectData": []
+                },
+                {
+                    "typeElementPropertyId": null,
+                    "developerName": "col_char",
+                    "contentType": "ContentString",
+                    "contentValue": "xxxx",
+                    "contentFormat": null,
+                    "objectData": []
+                },
+                {
+                    "typeElementPropertyId": null,
+                    "developerName": "col_varchar",
+                    "contentType": "ContentString",
+                    "contentValue": "bbbb",
+                    "contentFormat": null,
+                    "objectData": []
+                },
+                {
+                    "typeElementPropertyId": null,
+                    "developerName": "col_text",
+                    "contentType": "ContentString",
+                    "contentValue": "xxxx",
+                    "contentFormat": null,
+                    "objectData": []
+                }
+            ],
+            "isSelected": false
+        },
+        {
+            "internalId": null,
+            "externalId": "eyJpZCI6IjMifQ==",
+            "developerName": "searchtest",
+            "typeElementId": null,
+            "order": 0,
+            "properties": [
+                {
+                    "typeElementPropertyId": null,
+                    "developerName": "id",
+                    "contentType": "ContentNumber",
+                    "contentValue": "3",
+                    "contentFormat": null,
+                    "objectData": []
+                },
+                {
+                    "typeElementPropertyId": null,
+                    "developerName": "col_char",
+                    "contentType": "ContentString",
+                    "contentValue": "xxxx",
+                    "contentFormat": null,
+                    "objectData": []
+                },
+                {
+                    "typeElementPropertyId": null,
+                    "developerName": "col_varchar",
+                    "contentType": "ContentString",
+                    "contentValue": "xxxx",
+                    "contentFormat": null,
+                    "objectData": []
+                },
+                {
+                    "typeElementPropertyId": null,
+                    "developerName": "col_text",
+                    "contentType": "ContentString",
+                    "contentValue": "cccc",
+                    "contentFormat": null,
+                    "objectData": []
+                }
+            ],
+            "isSelected": false
+        },
+        {
+            "internalId": null,
+            "externalId": "eyJpZCI6IjQifQ==",
+            "developerName": "searchtest",
+            "typeElementId": null,
+            "order": 0,
+            "properties": [
+                {
+                    "typeElementPropertyId": null,
+                    "developerName": "id",
+                    "contentType": "ContentNumber",
+                    "contentValue": "4",
+                    "contentFormat": null,
+                    "objectData": []
+                },
+                {
+                    "typeElementPropertyId": null,
+                    "developerName": "col_char",
+                    "contentType": "ContentString",
+                    "contentValue": "zzzz",
+                    "contentFormat": null,
+                    "objectData": []
+                },
+                {
+                    "typeElementPropertyId": null,
+                    "developerName": "col_varchar",
+                    "contentType": "ContentString",
+                    "contentValue": "zzzz",
+                    "contentFormat": null,
+                    "objectData": []
+                },
+                {
+                    "typeElementPropertyId": null,
+                    "developerName": "col_text",
+                    "contentType": "ContentString",
+                    "contentValue": "zzzz",
+                    "contentFormat": null,
+                    "objectData": []
+                }
+            ],
+            "isSelected": false
+        }
+    ]
+}

--- a/src/test/resources/suites/postgresql/search/char-request.json
+++ b/src/test/resources/suites/postgresql/search/char-request.json
@@ -1,0 +1,148 @@
+{
+    "stateId": null,
+    "token": null,
+    "typeElementBindingId": null,
+    "authorization": {
+        "users": null,
+        "groups": null,
+        "runningAuthenticationId": null,
+        "globalAuthenticationType": "PUBLIC"
+    },
+    "configurationValues": [
+        {
+            "valueElementId": null,
+            "typeElementId": null,
+            "typeElementPropertyId": null,
+            "developerName": "Password",
+            "typeElementDeveloperName": null,
+            "typeElementPropertyDeveloperName": null,
+            "contentValue": "{{password}}",
+            "contentType": "ContentPassword",
+            "objectData": null
+        },
+        {
+            "valueElementId": null,
+            "typeElementId": null,
+            "typeElementPropertyId": null,
+            "developerName": "Database Type",
+            "typeElementDeveloperName": null,
+            "typeElementPropertyDeveloperName": null,
+            "contentValue": "{{databaseType}}",
+            "contentType": "ContentString",
+            "objectData": null
+        },
+        {
+            "valueElementId": null,
+            "typeElementId": null,
+            "typeElementPropertyId": null,
+            "developerName": "Database Name",
+            "typeElementDeveloperName": null,
+            "typeElementPropertyDeveloperName": null,
+            "contentValue": "{{databaseName}}",
+            "contentType": "ContentString",
+            "objectData": null
+        },
+        {
+            "valueElementId": null,
+            "typeElementId": null,
+            "typeElementPropertyId": null,
+            "developerName": "Port",
+            "typeElementDeveloperName": null,
+            "typeElementPropertyDeveloperName": null,
+            "contentValue": "{{port}}",
+            "contentType": "ContentNumber",
+            "objectData": null
+        },
+        {
+            "valueElementId": null,
+            "typeElementId": null,
+            "typeElementPropertyId": null,
+            "developerName": "Host",
+            "typeElementDeveloperName": null,
+            "typeElementPropertyDeveloperName": null,
+            "contentValue": "{{host}}",
+            "contentType": "ContentString",
+            "objectData": null
+        },
+        {
+            "valueElementId": null,
+            "typeElementId": null,
+            "typeElementPropertyId": null,
+            "developerName": "Database Schema",
+            "typeElementDeveloperName": null,
+            "typeElementPropertyDeveloperName": null,
+            "contentValue": "{{schema}}",
+            "contentType": "ContentString",
+            "objectData": null
+        },
+        {
+            "valueElementId": null,
+            "typeElementId": null,
+            "typeElementPropertyId": null,
+            "developerName": "Username",
+            "typeElementDeveloperName": null,
+            "typeElementPropertyDeveloperName": null,
+            "contentValue": "{{userName}}",
+            "contentType": "ContentString",
+            "objectData": null
+        },
+        {
+            "valueElementId": null,
+            "typeElementId": null,
+            "typeElementPropertyId": null,
+            "developerName": "No SSL",
+            "typeElementDeveloperName": null,
+            "typeElementPropertyDeveloperName": null,
+            "contentValue": "true",
+            "contentType": null,
+            "objectData": null
+        }
+    ],
+    "command": null,
+    "culture": {
+        "id": null,
+        "developerName": null,
+        "developerSummary": null,
+        "brand": null,
+        "language": "EN",
+        "country": "USA",
+        "variant": null
+    },
+    "listFilter": {
+        "id": null,
+        "filterByProvidedObjects": false,
+        "orderByPropertyDeveloperName": "id",
+        "orderByDirectionType": "",
+        "orderBy": null,
+        "limit": 0,
+        "offset": 0,
+        "search": "aa",
+        "searchCriteria": null,
+        "comparisonType": "OR",
+        "where": null,
+        "listFilters": null
+    },
+    "objectDataType": {
+        "typeElementId": "737809a7-5825-4b04-8d38-b271963732e5",
+        "developerName": "searchtest",
+        "properties": [
+            {
+                "developerName": "id",
+                "list": null
+            },
+            {
+                "developerName": "col_char",
+                "list": null
+            },
+            {
+                "developerName": "col_varchar",
+                "list": null
+            },
+            {
+                "developerName": "col_text",
+                "list": null
+            }
+        ]
+    },
+    "objectData": null
+}

--- a/src/test/resources/suites/postgresql/search/char-response.json
+++ b/src/test/resources/suites/postgresql/search/char-response.json
@@ -1,0 +1,48 @@
+{
+    "culture": null,
+    "hasMoreResults": false,
+    "objectData": [
+        {
+            "internalId": null,
+            "externalId": "eyJpZCI6IjEifQ==",
+            "developerName": "searchtest",
+            "typeElementId": null,
+            "order": 0,
+            "properties": [
+                {
+                    "typeElementPropertyId": null,
+                    "developerName": "id",
+                    "contentType": "ContentNumber",
+                    "contentValue": "1",
+                    "contentFormat": null,
+                    "objectData": []
+                },
+                {
+                    "typeElementPropertyId": null,
+                    "developerName": "col_char",
+                    "contentType": "ContentString",
+                    "contentValue": "aaaa",
+                    "contentFormat": null,
+                    "objectData": []
+                },
+                {
+                    "typeElementPropertyId": null,
+                    "developerName": "col_varchar",
+                    "contentType": "ContentString",
+                    "contentValue": "xxxx",
+                    "contentFormat": null,
+                    "objectData": []
+                },
+                {
+                    "typeElementPropertyId": null,
+                    "developerName": "col_text",
+                    "contentType": "ContentString",
+                    "contentValue": "xxxx",
+                    "contentFormat": null,
+                    "objectData": []
+                }
+            ],
+            "isSelected": false
+        }
+    ]
+}

--- a/src/test/resources/suites/postgresql/search/noresults-request.json
+++ b/src/test/resources/suites/postgresql/search/noresults-request.json
@@ -1,0 +1,148 @@
+{
+    "stateId": null,
+    "token": null,
+    "typeElementBindingId": null,
+    "authorization": {
+        "users": null,
+        "groups": null,
+        "runningAuthenticationId": null,
+        "globalAuthenticationType": "PUBLIC"
+    },
+    "configurationValues": [
+        {
+            "valueElementId": null,
+            "typeElementId": null,
+            "typeElementPropertyId": null,
+            "developerName": "Password",
+            "typeElementDeveloperName": null,
+            "typeElementPropertyDeveloperName": null,
+            "contentValue": "{{password}}",
+            "contentType": "ContentPassword",
+            "objectData": null
+        },
+        {
+            "valueElementId": null,
+            "typeElementId": null,
+            "typeElementPropertyId": null,
+            "developerName": "Database Type",
+            "typeElementDeveloperName": null,
+            "typeElementPropertyDeveloperName": null,
+            "contentValue": "{{databaseType}}",
+            "contentType": "ContentString",
+            "objectData": null
+        },
+        {
+            "valueElementId": null,
+            "typeElementId": null,
+            "typeElementPropertyId": null,
+            "developerName": "Database Name",
+            "typeElementDeveloperName": null,
+            "typeElementPropertyDeveloperName": null,
+            "contentValue": "{{databaseName}}",
+            "contentType": "ContentString",
+            "objectData": null
+        },
+        {
+            "valueElementId": null,
+            "typeElementId": null,
+            "typeElementPropertyId": null,
+            "developerName": "Port",
+            "typeElementDeveloperName": null,
+            "typeElementPropertyDeveloperName": null,
+            "contentValue": "{{port}}",
+            "contentType": "ContentNumber",
+            "objectData": null
+        },
+        {
+            "valueElementId": null,
+            "typeElementId": null,
+            "typeElementPropertyId": null,
+            "developerName": "Host",
+            "typeElementDeveloperName": null,
+            "typeElementPropertyDeveloperName": null,
+            "contentValue": "{{host}}",
+            "contentType": "ContentString",
+            "objectData": null
+        },
+        {
+            "valueElementId": null,
+            "typeElementId": null,
+            "typeElementPropertyId": null,
+            "developerName": "Database Schema",
+            "typeElementDeveloperName": null,
+            "typeElementPropertyDeveloperName": null,
+            "contentValue": "{{schema}}",
+            "contentType": "ContentString",
+            "objectData": null
+        },
+        {
+            "valueElementId": null,
+            "typeElementId": null,
+            "typeElementPropertyId": null,
+            "developerName": "Username",
+            "typeElementDeveloperName": null,
+            "typeElementPropertyDeveloperName": null,
+            "contentValue": "{{userName}}",
+            "contentType": "ContentString",
+            "objectData": null
+        },
+        {
+            "valueElementId": null,
+            "typeElementId": null,
+            "typeElementPropertyId": null,
+            "developerName": "No SSL",
+            "typeElementDeveloperName": null,
+            "typeElementPropertyDeveloperName": null,
+            "contentValue": "true",
+            "contentType": null,
+            "objectData": null
+        }
+    ],
+    "command": null,
+    "culture": {
+        "id": null,
+        "developerName": null,
+        "developerSummary": null,
+        "brand": null,
+        "language": "EN",
+        "country": "USA",
+        "variant": null
+    },
+    "listFilter": {
+        "id": null,
+        "filterByProvidedObjects": false,
+        "orderByPropertyDeveloperName": "id",
+        "orderByDirectionType": "",
+        "orderBy": null,
+        "limit": 0,
+        "offset": 0,
+        "search": "noresults",
+        "searchCriteria": null,
+        "comparisonType": "OR",
+        "where": null,
+        "listFilters": null
+    },
+    "objectDataType": {
+        "typeElementId": "737809a7-5825-4b04-8d38-b271963732e5",
+        "developerName": "searchtest",
+        "properties": [
+            {
+                "developerName": "id",
+                "list": null
+            },
+            {
+                "developerName": "col_char",
+                "list": null
+            },
+            {
+                "developerName": "col_varchar",
+                "list": null
+            },
+            {
+                "developerName": "col_text",
+                "list": null
+            }
+        ]
+    },
+    "objectData": null
+}

--- a/src/test/resources/suites/postgresql/search/noresults-response.json
+++ b/src/test/resources/suites/postgresql/search/noresults-response.json
@@ -1,0 +1,5 @@
+{
+    "culture": null,
+    "hasMoreResults": false,
+    "objectData": []
+}

--- a/src/test/resources/suites/postgresql/search/text-request.json
+++ b/src/test/resources/suites/postgresql/search/text-request.json
@@ -1,0 +1,148 @@
+{
+    "stateId": null,
+    "token": null,
+    "typeElementBindingId": null,
+    "authorization": {
+        "users": null,
+        "groups": null,
+        "runningAuthenticationId": null,
+        "globalAuthenticationType": "PUBLIC"
+    },
+    "configurationValues": [
+        {
+            "valueElementId": null,
+            "typeElementId": null,
+            "typeElementPropertyId": null,
+            "developerName": "Password",
+            "typeElementDeveloperName": null,
+            "typeElementPropertyDeveloperName": null,
+            "contentValue": "{{password}}",
+            "contentType": "ContentPassword",
+            "objectData": null
+        },
+        {
+            "valueElementId": null,
+            "typeElementId": null,
+            "typeElementPropertyId": null,
+            "developerName": "Database Type",
+            "typeElementDeveloperName": null,
+            "typeElementPropertyDeveloperName": null,
+            "contentValue": "{{databaseType}}",
+            "contentType": "ContentString",
+            "objectData": null
+        },
+        {
+            "valueElementId": null,
+            "typeElementId": null,
+            "typeElementPropertyId": null,
+            "developerName": "Database Name",
+            "typeElementDeveloperName": null,
+            "typeElementPropertyDeveloperName": null,
+            "contentValue": "{{databaseName}}",
+            "contentType": "ContentString",
+            "objectData": null
+        },
+        {
+            "valueElementId": null,
+            "typeElementId": null,
+            "typeElementPropertyId": null,
+            "developerName": "Port",
+            "typeElementDeveloperName": null,
+            "typeElementPropertyDeveloperName": null,
+            "contentValue": "{{port}}",
+            "contentType": "ContentNumber",
+            "objectData": null
+        },
+        {
+            "valueElementId": null,
+            "typeElementId": null,
+            "typeElementPropertyId": null,
+            "developerName": "Host",
+            "typeElementDeveloperName": null,
+            "typeElementPropertyDeveloperName": null,
+            "contentValue": "{{host}}",
+            "contentType": "ContentString",
+            "objectData": null
+        },
+        {
+            "valueElementId": null,
+            "typeElementId": null,
+            "typeElementPropertyId": null,
+            "developerName": "Database Schema",
+            "typeElementDeveloperName": null,
+            "typeElementPropertyDeveloperName": null,
+            "contentValue": "{{schema}}",
+            "contentType": "ContentString",
+            "objectData": null
+        },
+        {
+            "valueElementId": null,
+            "typeElementId": null,
+            "typeElementPropertyId": null,
+            "developerName": "Username",
+            "typeElementDeveloperName": null,
+            "typeElementPropertyDeveloperName": null,
+            "contentValue": "{{userName}}",
+            "contentType": "ContentString",
+            "objectData": null
+        },
+        {
+            "valueElementId": null,
+            "typeElementId": null,
+            "typeElementPropertyId": null,
+            "developerName": "No SSL",
+            "typeElementDeveloperName": null,
+            "typeElementPropertyDeveloperName": null,
+            "contentValue": "true",
+            "contentType": null,
+            "objectData": null
+        }
+    ],
+    "command": null,
+    "culture": {
+        "id": null,
+        "developerName": null,
+        "developerSummary": null,
+        "brand": null,
+        "language": "EN",
+        "country": "USA",
+        "variant": null
+    },
+    "listFilter": {
+        "id": null,
+        "filterByProvidedObjects": false,
+        "orderByPropertyDeveloperName": "id",
+        "orderByDirectionType": "",
+        "orderBy": null,
+        "limit": 0,
+        "offset": 0,
+        "search": "cc",
+        "searchCriteria": null,
+        "comparisonType": "OR",
+        "where": null,
+        "listFilters": null
+    },
+    "objectDataType": {
+        "typeElementId": "737809a7-5825-4b04-8d38-b271963732e5",
+        "developerName": "searchtest",
+        "properties": [
+            {
+                "developerName": "id",
+                "list": null
+            },
+            {
+                "developerName": "col_char",
+                "list": null
+            },
+            {
+                "developerName": "col_varchar",
+                "list": null
+            },
+            {
+                "developerName": "col_text",
+                "list": null
+            }
+        ]
+    },
+    "objectData": null
+}

--- a/src/test/resources/suites/postgresql/search/text-response.json
+++ b/src/test/resources/suites/postgresql/search/text-response.json
@@ -1,0 +1,48 @@
+{
+    "culture": null,
+    "hasMoreResults": false,
+    "objectData": [
+        {
+            "internalId": null,
+            "externalId": "eyJpZCI6IjMifQ==",
+            "developerName": "searchtest",
+            "typeElementId": null,
+            "order": 0,
+            "properties": [
+                {
+                    "typeElementPropertyId": null,
+                    "developerName": "id",
+                    "contentType": "ContentNumber",
+                    "contentValue": "3",
+                    "contentFormat": null,
+                    "objectData": []
+                },
+                {
+                    "typeElementPropertyId": null,
+                    "developerName": "col_char",
+                    "contentType": "ContentString",
+                    "contentValue": "xxxx",
+                    "contentFormat": null,
+                    "objectData": []
+                },
+                {
+                    "typeElementPropertyId": null,
+                    "developerName": "col_varchar",
+                    "contentType": "ContentString",
+                    "contentValue": "xxxx",
+                    "contentFormat": null,
+                    "objectData": []
+                },
+                {
+                    "typeElementPropertyId": null,
+                    "developerName": "col_text",
+                    "contentType": "ContentString",
+                    "contentValue": "cccc",
+                    "contentFormat": null,
+                    "objectData": []
+                }
+            ],
+            "isSelected": false
+        }
+    ]
+}

--- a/src/test/resources/suites/postgresql/search/varchar-request.json
+++ b/src/test/resources/suites/postgresql/search/varchar-request.json
@@ -1,0 +1,148 @@
+{
+    "stateId": null,
+    "token": null,
+    "typeElementBindingId": null,
+    "authorization": {
+        "users": null,
+        "groups": null,
+        "runningAuthenticationId": null,
+        "globalAuthenticationType": "PUBLIC"
+    },
+    "configurationValues": [
+        {
+            "valueElementId": null,
+            "typeElementId": null,
+            "typeElementPropertyId": null,
+            "developerName": "Password",
+            "typeElementDeveloperName": null,
+            "typeElementPropertyDeveloperName": null,
+            "contentValue": "{{password}}",
+            "contentType": "ContentPassword",
+            "objectData": null
+        },
+        {
+            "valueElementId": null,
+            "typeElementId": null,
+            "typeElementPropertyId": null,
+            "developerName": "Database Type",
+            "typeElementDeveloperName": null,
+            "typeElementPropertyDeveloperName": null,
+            "contentValue": "{{databaseType}}",
+            "contentType": "ContentString",
+            "objectData": null
+        },
+        {
+            "valueElementId": null,
+            "typeElementId": null,
+            "typeElementPropertyId": null,
+            "developerName": "Database Name",
+            "typeElementDeveloperName": null,
+            "typeElementPropertyDeveloperName": null,
+            "contentValue": "{{databaseName}}",
+            "contentType": "ContentString",
+            "objectData": null
+        },
+        {
+            "valueElementId": null,
+            "typeElementId": null,
+            "typeElementPropertyId": null,
+            "developerName": "Port",
+            "typeElementDeveloperName": null,
+            "typeElementPropertyDeveloperName": null,
+            "contentValue": "{{port}}",
+            "contentType": "ContentNumber",
+            "objectData": null
+        },
+        {
+            "valueElementId": null,
+            "typeElementId": null,
+            "typeElementPropertyId": null,
+            "developerName": "Host",
+            "typeElementDeveloperName": null,
+            "typeElementPropertyDeveloperName": null,
+            "contentValue": "{{host}}",
+            "contentType": "ContentString",
+            "objectData": null
+        },
+        {
+            "valueElementId": null,
+            "typeElementId": null,
+            "typeElementPropertyId": null,
+            "developerName": "Database Schema",
+            "typeElementDeveloperName": null,
+            "typeElementPropertyDeveloperName": null,
+            "contentValue": "{{schema}}",
+            "contentType": "ContentString",
+            "objectData": null
+        },
+        {
+            "valueElementId": null,
+            "typeElementId": null,
+            "typeElementPropertyId": null,
+            "developerName": "Username",
+            "typeElementDeveloperName": null,
+            "typeElementPropertyDeveloperName": null,
+            "contentValue": "{{userName}}",
+            "contentType": "ContentString",
+            "objectData": null
+        },
+        {
+            "valueElementId": null,
+            "typeElementId": null,
+            "typeElementPropertyId": null,
+            "developerName": "No SSL",
+            "typeElementDeveloperName": null,
+            "typeElementPropertyDeveloperName": null,
+            "contentValue": "true",
+            "contentType": null,
+            "objectData": null
+        }
+    ],
+    "command": null,
+    "culture": {
+        "id": null,
+        "developerName": null,
+        "developerSummary": null,
+        "brand": null,
+        "language": "EN",
+        "country": "USA",
+        "variant": null
+    },
+    "listFilter": {
+        "id": null,
+        "filterByProvidedObjects": false,
+        "orderByPropertyDeveloperName": "id",
+        "orderByDirectionType": "",
+        "orderBy": null,
+        "limit": 0,
+        "offset": 0,
+        "search": "bb",
+        "searchCriteria": null,
+        "comparisonType": "OR",
+        "where": null,
+        "listFilters": null
+    },
+    "objectDataType": {
+        "typeElementId": "737809a7-5825-4b04-8d38-b271963732e5",
+        "developerName": "searchtest",
+        "properties": [
+            {
+                "developerName": "id",
+                "list": null
+            },
+            {
+                "developerName": "col_char",
+                "list": null
+            },
+            {
+                "developerName": "col_varchar",
+                "list": null
+            },
+            {
+                "developerName": "col_text",
+                "list": null
+            }
+        ]
+    },
+    "objectData": null
+}

--- a/src/test/resources/suites/postgresql/search/varchar-response.json
+++ b/src/test/resources/suites/postgresql/search/varchar-response.json
@@ -1,0 +1,48 @@
+{
+    "culture": null,
+    "hasMoreResults": false,
+    "objectData": [
+        {
+            "internalId": null,
+            "externalId": "eyJpZCI6IjIifQ==",
+            "developerName": "searchtest",
+            "typeElementId": null,
+            "order": 0,
+            "properties": [
+                {
+                    "typeElementPropertyId": null,
+                    "developerName": "id",
+                    "contentType": "ContentNumber",
+                    "contentValue": "2",
+                    "contentFormat": null,
+                    "objectData": []
+                },
+                {
+                    "typeElementPropertyId": null,
+                    "developerName": "col_char",
+                    "contentType": "ContentString",
+                    "contentValue": "xxxx",
+                    "contentFormat": null,
+                    "objectData": []
+                },
+                {
+                    "typeElementPropertyId": null,
+                    "developerName": "col_varchar",
+                    "contentType": "ContentString",
+                    "contentValue": "bbbb",
+                    "contentFormat": null,
+                    "objectData": []
+                },
+                {
+                    "typeElementPropertyId": null,
+                    "developerName": "col_text",
+                    "contentType": "ContentString",
+                    "contentValue": "xxxx",
+                    "contentFormat": null,
+                    "objectData": []
+                }
+            ],
+            "isSelected": false
+        }
+    ]
+}

--- a/src/test/resources/suites/postgresql/search/xxxx-request.json
+++ b/src/test/resources/suites/postgresql/search/xxxx-request.json
@@ -1,0 +1,148 @@
+{
+    "stateId": null,
+    "token": null,
+    "typeElementBindingId": null,
+    "authorization": {
+        "users": null,
+        "groups": null,
+        "runningAuthenticationId": null,
+        "globalAuthenticationType": "PUBLIC"
+    },
+    "configurationValues": [
+        {
+            "valueElementId": null,
+            "typeElementId": null,
+            "typeElementPropertyId": null,
+            "developerName": "Password",
+            "typeElementDeveloperName": null,
+            "typeElementPropertyDeveloperName": null,
+            "contentValue": "{{password}}",
+            "contentType": "ContentPassword",
+            "objectData": null
+        },
+        {
+            "valueElementId": null,
+            "typeElementId": null,
+            "typeElementPropertyId": null,
+            "developerName": "Database Type",
+            "typeElementDeveloperName": null,
+            "typeElementPropertyDeveloperName": null,
+            "contentValue": "{{databaseType}}",
+            "contentType": "ContentString",
+            "objectData": null
+        },
+        {
+            "valueElementId": null,
+            "typeElementId": null,
+            "typeElementPropertyId": null,
+            "developerName": "Database Name",
+            "typeElementDeveloperName": null,
+            "typeElementPropertyDeveloperName": null,
+            "contentValue": "{{databaseName}}",
+            "contentType": "ContentString",
+            "objectData": null
+        },
+        {
+            "valueElementId": null,
+            "typeElementId": null,
+            "typeElementPropertyId": null,
+            "developerName": "Port",
+            "typeElementDeveloperName": null,
+            "typeElementPropertyDeveloperName": null,
+            "contentValue": "{{port}}",
+            "contentType": "ContentNumber",
+            "objectData": null
+        },
+        {
+            "valueElementId": null,
+            "typeElementId": null,
+            "typeElementPropertyId": null,
+            "developerName": "Host",
+            "typeElementDeveloperName": null,
+            "typeElementPropertyDeveloperName": null,
+            "contentValue": "{{host}}",
+            "contentType": "ContentString",
+            "objectData": null
+        },
+        {
+            "valueElementId": null,
+            "typeElementId": null,
+            "typeElementPropertyId": null,
+            "developerName": "Database Schema",
+            "typeElementDeveloperName": null,
+            "typeElementPropertyDeveloperName": null,
+            "contentValue": "{{schema}}",
+            "contentType": "ContentString",
+            "objectData": null
+        },
+        {
+            "valueElementId": null,
+            "typeElementId": null,
+            "typeElementPropertyId": null,
+            "developerName": "Username",
+            "typeElementDeveloperName": null,
+            "typeElementPropertyDeveloperName": null,
+            "contentValue": "{{userName}}",
+            "contentType": "ContentString",
+            "objectData": null
+        },
+        {
+            "valueElementId": null,
+            "typeElementId": null,
+            "typeElementPropertyId": null,
+            "developerName": "No SSL",
+            "typeElementDeveloperName": null,
+            "typeElementPropertyDeveloperName": null,
+            "contentValue": "true",
+            "contentType": null,
+            "objectData": null
+        }
+    ],
+    "command": null,
+    "culture": {
+        "id": null,
+        "developerName": null,
+        "developerSummary": null,
+        "brand": null,
+        "language": "EN",
+        "country": "USA",
+        "variant": null
+    },
+    "listFilter": {
+        "id": null,
+        "filterByProvidedObjects": false,
+        "orderByPropertyDeveloperName": "id",
+        "orderByDirectionType": "",
+        "orderBy": null,
+        "limit": 0,
+        "offset": 0,
+        "search": "xx",
+        "searchCriteria": null,
+        "comparisonType": "OR",
+        "where": null,
+        "listFilters": null
+    },
+    "objectDataType": {
+        "typeElementId": "737809a7-5825-4b04-8d38-b271963732e5",
+        "developerName": "searchtest",
+        "properties": [
+            {
+                "developerName": "id",
+                "list": null
+            },
+            {
+                "developerName": "col_char",
+                "list": null
+            },
+            {
+                "developerName": "col_varchar",
+                "list": null
+            },
+            {
+                "developerName": "col_text",
+                "list": null
+            }
+        ]
+    },
+    "objectData": null
+}

--- a/src/test/resources/suites/postgresql/search/xxxx-response.json
+++ b/src/test/resources/suites/postgresql/search/xxxx-response.json
@@ -1,0 +1,132 @@
+{
+    "culture": null,
+    "hasMoreResults": false,
+    "objectData": [
+        {
+            "internalId": null,
+            "externalId": "eyJpZCI6IjEifQ==",
+            "developerName": "searchtest",
+            "typeElementId": null,
+            "order": 0,
+            "properties": [
+                {
+                    "typeElementPropertyId": null,
+                    "developerName": "id",
+                    "contentType": "ContentNumber",
+                    "contentValue": "1",
+                    "contentFormat": null,
+                    "objectData": []
+                },
+                {
+                    "typeElementPropertyId": null,
+                    "developerName": "col_char",
+                    "contentType": "ContentString",
+                    "contentValue": "aaaa",
+                    "contentFormat": null,
+                    "objectData": []
+                },
+                {
+                    "typeElementPropertyId": null,
+                    "developerName": "col_varchar",
+                    "contentType": "ContentString",
+                    "contentValue": "xxxx",
+                    "contentFormat": null,
+                    "objectData": []
+                },
+                {
+                    "typeElementPropertyId": null,
+                    "developerName": "col_text",
+                    "contentType": "ContentString",
+                    "contentValue": "xxxx",
+                    "contentFormat": null,
+                    "objectData": []
+                }
+            ],
+            "isSelected": false
+        },
+        {
+            "internalId": null,
+            "externalId": "eyJpZCI6IjIifQ==",
+            "developerName": "searchtest",
+            "typeElementId": null,
+            "order": 0,
+            "properties": [
+                {
+                    "typeElementPropertyId": null,
+                    "developerName": "id",
+                    "contentType": "ContentNumber",
+                    "contentValue": "2",
+                    "contentFormat": null,
+                    "objectData": []
+                },
+                {
+                    "typeElementPropertyId": null,
+                    "developerName": "col_char",
+                    "contentType": "ContentString",
+                    "contentValue": "xxxx",
+                    "contentFormat": null,
+                    "objectData": []
+                },
+                {
+                    "typeElementPropertyId": null,
+                    "developerName": "col_varchar",
+                    "contentType": "ContentString",
+                    "contentValue": "bbbb",
+                    "contentFormat": null,
+                    "objectData": []
+                },
+                {
+                    "typeElementPropertyId": null,
+                    "developerName": "col_text",
+                    "contentType": "ContentString",
+                    "contentValue": "xxxx",
+                    "contentFormat": null,
+                    "objectData": []
+                }
+            ],
+            "isSelected": false
+        },
+        {
+            "internalId": null,
+            "externalId": "eyJpZCI6IjMifQ==",
+            "developerName": "searchtest",
+            "typeElementId": null,
+            "order": 0,
+            "properties": [
+                {
+                    "typeElementPropertyId": null,
+                    "developerName": "id",
+                    "contentType": "ContentNumber",
+                    "contentValue": "3",
+                    "contentFormat": null,
+                    "objectData": []
+                },
+                {
+                    "typeElementPropertyId": null,
+                    "developerName": "col_char",
+                    "contentType": "ContentString",
+                    "contentValue": "xxxx",
+                    "contentFormat": null,
+                    "objectData": []
+                },
+                {
+                    "typeElementPropertyId": null,
+                    "developerName": "col_varchar",
+                    "contentType": "ContentString",
+                    "contentValue": "xxxx",
+                    "contentFormat": null,
+                    "objectData": []
+                },
+                {
+                    "typeElementPropertyId": null,
+                    "developerName": "col_text",
+                    "contentType": "ContentString",
+                    "contentValue": "cccc",
+                    "contentFormat": null,
+                    "objectData": []
+                }
+            ],
+            "isSelected": false
+        }
+   ]
+}

--- a/src/test/resources/suites/sqlserver/search/allresults-request.json
+++ b/src/test/resources/suites/sqlserver/search/allresults-request.json
@@ -1,0 +1,160 @@
+{
+    "stateId": null,
+    "token": null,
+    "typeElementBindingId": null,
+    "authorization": {
+        "users": null,
+        "groups": null,
+        "runningAuthenticationId": null,
+        "globalAuthenticationType": "PUBLIC"
+    },
+    "configurationValues": [
+        {
+            "valueElementId": null,
+            "typeElementId": null,
+            "typeElementPropertyId": null,
+            "developerName": "Password",
+            "typeElementDeveloperName": null,
+            "typeElementPropertyDeveloperName": null,
+            "contentValue": "{{password}}",
+            "contentType": "ContentPassword",
+            "objectData": null
+        },
+        {
+            "valueElementId": null,
+            "typeElementId": null,
+            "typeElementPropertyId": null,
+            "developerName": "Database Type",
+            "typeElementDeveloperName": null,
+            "typeElementPropertyDeveloperName": null,
+            "contentValue": "{{databaseType}}",
+            "contentType": "ContentString",
+            "objectData": null
+        },
+        {
+            "valueElementId": null,
+            "typeElementId": null,
+            "typeElementPropertyId": null,
+            "developerName": "Database Name",
+            "typeElementDeveloperName": null,
+            "typeElementPropertyDeveloperName": null,
+            "contentValue": "{{databaseName}}",
+            "contentType": "ContentString",
+            "objectData": null
+        },
+        {
+            "valueElementId": null,
+            "typeElementId": null,
+            "typeElementPropertyId": null,
+            "developerName": "Port",
+            "typeElementDeveloperName": null,
+            "typeElementPropertyDeveloperName": null,
+            "contentValue": "{{port}}",
+            "contentType": "ContentNumber",
+            "objectData": null
+        },
+        {
+            "valueElementId": null,
+            "typeElementId": null,
+            "typeElementPropertyId": null,
+            "developerName": "Host",
+            "typeElementDeveloperName": null,
+            "typeElementPropertyDeveloperName": null,
+            "contentValue": "{{host}}",
+            "contentType": "ContentString",
+            "objectData": null
+        },
+        {
+            "valueElementId": null,
+            "typeElementId": null,
+            "typeElementPropertyId": null,
+            "developerName": "Database Schema",
+            "typeElementDeveloperName": null,
+            "typeElementPropertyDeveloperName": null,
+            "contentValue": "{{schema}}",
+            "contentType": "ContentString",
+            "objectData": null
+        },
+        {
+            "valueElementId": null,
+            "typeElementId": null,
+            "typeElementPropertyId": null,
+            "developerName": "Username",
+            "typeElementDeveloperName": null,
+            "typeElementPropertyDeveloperName": null,
+            "contentValue": "{{userName}}",
+            "contentType": "ContentString",
+            "objectData": null
+        },
+        {
+            "valueElementId": null,
+            "typeElementId": null,
+            "typeElementPropertyId": null,
+            "developerName": "No SSL",
+            "typeElementDeveloperName": null,
+            "typeElementPropertyDeveloperName": null,
+            "contentValue": "true",
+            "contentType": null,
+            "objectData": null
+        }
+    ],
+    "command": null,
+    "culture": {
+        "id": null,
+        "developerName": null,
+        "developerSummary": null,
+        "brand": null,
+        "language": "EN",
+        "country": "USA",
+        "variant": null
+    },
+    "listFilter": {
+        "id": null,
+        "filterByProvidedObjects": false,
+        "orderByPropertyDeveloperName": "id",
+        "orderByDirectionType": "",
+        "orderBy": null,
+        "limit": 0,
+        "offset": 0,
+        "search": null,
+        "searchCriteria": null,
+        "comparisonType": "OR",
+        "where": null,
+        "listFilters": null
+    },
+    "objectDataType": {
+        "typeElementId": "737809a7-5825-4b04-8d38-b271963732e5",
+        "developerName": "searchtest",
+        "properties": [
+            {
+                "developerName": "id",
+                "list": null
+            },
+            {
+                "developerName": "col_char",
+                "list": null
+            },
+            {
+                "developerName": "col_nchar",
+                "list": null
+            },
+            {
+                "developerName": "col_varchar",
+                "list": null
+            },
+            {
+                "developerName": "col_nvarchar",
+                "list": null
+            },
+            {
+                "developerName": "col_text",
+                "list": null
+            },
+            {
+                "developerName": "col_ntext",
+                "list": null
+            }
+        ]
+    },
+    "objectData": null
+}

--- a/src/test/resources/suites/sqlserver/search/allresults-response.json
+++ b/src/test/resources/suites/sqlserver/search/allresults-response.json
@@ -1,0 +1,468 @@
+{
+    "culture": null,
+    "hasMoreResults": false,
+    "objectData": [
+        {
+            "internalId": null,
+            "externalId": "eyJpZCI6IjEifQ==",
+            "developerName": "searchtest",
+            "typeElementId": null,
+            "order": 0,
+            "properties": [
+                {
+                    "typeElementPropertyId": null,
+                    "developerName": "id",
+                    "contentType": "ContentNumber",
+                    "contentValue": "1",
+                    "contentFormat": null,
+                    "objectData": []
+                },
+                {
+                    "typeElementPropertyId": null,
+                    "developerName": "col_char",
+                    "contentType": "ContentString",
+                    "contentValue": "aaaa",
+                    "contentFormat": null,
+                    "objectData": []
+                },
+                {
+                    "typeElementPropertyId": null,
+                    "developerName": "col_nchar",
+                    "contentType": "ContentString",
+                    "contentValue": "xxxx",
+                    "contentFormat": null,
+                    "objectData": []
+                },
+                {
+                    "typeElementPropertyId": null,
+                    "developerName": "col_varchar",
+                    "contentType": "ContentString",
+                    "contentValue": "xxxx",
+                    "contentFormat": null,
+                    "objectData": []
+                },
+                {
+                    "typeElementPropertyId": null,
+                    "developerName": "col_nvarchar",
+                    "contentType": "ContentString",
+                    "contentValue": "xxxx",
+                    "contentFormat": null,
+                    "objectData": []
+                },
+                {
+                    "typeElementPropertyId": null,
+                    "developerName": "col_text",
+                    "contentType": "ContentString",
+                    "contentValue": "xxxx",
+                    "contentFormat": null,
+                    "objectData": []
+                },
+                {
+                    "typeElementPropertyId": null,
+                    "developerName": "col_ntext",
+                    "contentType": "ContentString",
+                    "contentValue": "xxxx",
+                    "contentFormat": null,
+                    "objectData": []
+                }
+            ],
+            "isSelected": false
+        },
+        {
+            "internalId": null,
+            "externalId": "eyJpZCI6IjIifQ==",
+            "developerName": "searchtest",
+            "typeElementId": null,
+            "order": 0,
+            "properties": [
+                {
+                    "typeElementPropertyId": null,
+                    "developerName": "id",
+                    "contentType": "ContentNumber",
+                    "contentValue": "2",
+                    "contentFormat": null,
+                    "objectData": []
+                },
+                {
+                    "typeElementPropertyId": null,
+                    "developerName": "col_char",
+                    "contentType": "ContentString",
+                    "contentValue": "xxxx",
+                    "contentFormat": null,
+                    "objectData": []
+                },
+                {
+                    "typeElementPropertyId": null,
+                    "developerName": "col_nchar",
+                    "contentType": "ContentString",
+                    "contentValue": "bbbb",
+                    "contentFormat": null,
+                    "objectData": []
+                },
+                {
+                    "typeElementPropertyId": null,
+                    "developerName": "col_varchar",
+                    "contentType": "ContentString",
+                    "contentValue": "xxxx",
+                    "contentFormat": null,
+                    "objectData": []
+                },
+                {
+                    "typeElementPropertyId": null,
+                    "developerName": "col_nvarchar",
+                    "contentType": "ContentString",
+                    "contentValue": "xxxx",
+                    "contentFormat": null,
+                    "objectData": []
+                },
+                {
+                    "typeElementPropertyId": null,
+                    "developerName": "col_text",
+                    "contentType": "ContentString",
+                    "contentValue": "xxxx",
+                    "contentFormat": null,
+                    "objectData": []
+                },
+                {
+                    "typeElementPropertyId": null,
+                    "developerName": "col_ntext",
+                    "contentType": "ContentString",
+                    "contentValue": "xxxx",
+                    "contentFormat": null,
+                    "objectData": []
+                }
+            ],
+            "isSelected": false
+        },
+        {
+            "internalId": null,
+            "externalId": "eyJpZCI6IjMifQ==",
+            "developerName": "searchtest",
+            "typeElementId": null,
+            "order": 0,
+            "properties": [
+                {
+                    "typeElementPropertyId": null,
+                    "developerName": "id",
+                    "contentType": "ContentNumber",
+                    "contentValue": "3",
+                    "contentFormat": null,
+                    "objectData": []
+                },
+                {
+                    "typeElementPropertyId": null,
+                    "developerName": "col_char",
+                    "contentType": "ContentString",
+                    "contentValue": "xxxx",
+                    "contentFormat": null,
+                    "objectData": []
+                },
+                {
+                    "typeElementPropertyId": null,
+                    "developerName": "col_nchar",
+                    "contentType": "ContentString",
+                    "contentValue": "xxxx",
+                    "contentFormat": null,
+                    "objectData": []
+                },
+                {
+                    "typeElementPropertyId": null,
+                    "developerName": "col_varchar",
+                    "contentType": "ContentString",
+                    "contentValue": "cccc",
+                    "contentFormat": null,
+                    "objectData": []
+                },
+                {
+                    "typeElementPropertyId": null,
+                    "developerName": "col_nvarchar",
+                    "contentType": "ContentString",
+                    "contentValue": "xxxx",
+                    "contentFormat": null,
+                    "objectData": []
+                },
+                {
+                    "typeElementPropertyId": null,
+                    "developerName": "col_text",
+                    "contentType": "ContentString",
+                    "contentValue": "xxxx",
+                    "contentFormat": null,
+                    "objectData": []
+                },
+                {
+                    "typeElementPropertyId": null,
+                    "developerName": "col_ntext",
+                    "contentType": "ContentString",
+                    "contentValue": "xxxx",
+                    "contentFormat": null,
+                    "objectData": []
+                }
+            ],
+            "isSelected": false
+        },
+        {
+            "internalId": null,
+            "externalId": "eyJpZCI6IjQifQ==",
+            "developerName": "searchtest",
+            "typeElementId": null,
+            "order": 0,
+            "properties": [
+                {
+                    "typeElementPropertyId": null,
+                    "developerName": "id",
+                    "contentType": "ContentNumber",
+                    "contentValue": "4",
+                    "contentFormat": null,
+                    "objectData": []
+                },
+                {
+                    "typeElementPropertyId": null,
+                    "developerName": "col_char",
+                    "contentType": "ContentString",
+                    "contentValue": "xxxx",
+                    "contentFormat": null,
+                    "objectData": []
+                },
+                {
+                    "typeElementPropertyId": null,
+                    "developerName": "col_nchar",
+                    "contentType": "ContentString",
+                    "contentValue": "xxxx",
+                    "contentFormat": null,
+                    "objectData": []
+                },
+                {
+                    "typeElementPropertyId": null,
+                    "developerName": "col_varchar",
+                    "contentType": "ContentString",
+                    "contentValue": "xxxx",
+                    "contentFormat": null,
+                    "objectData": []
+                },
+                {
+                    "typeElementPropertyId": null,
+                    "developerName": "col_nvarchar",
+                    "contentType": "ContentString",
+                    "contentValue": "dddd",
+                    "contentFormat": null,
+                    "objectData": []
+                },
+                {
+                    "typeElementPropertyId": null,
+                    "developerName": "col_text",
+                    "contentType": "ContentString",
+                    "contentValue": "xxxx",
+                    "contentFormat": null,
+                    "objectData": []
+                },
+                {
+                    "typeElementPropertyId": null,
+                    "developerName": "col_ntext",
+                    "contentType": "ContentString",
+                    "contentValue": "xxxx",
+                    "contentFormat": null,
+                    "objectData": []
+                }
+            ],
+            "isSelected": false
+        },
+        {
+            "internalId": null,
+            "externalId": "eyJpZCI6IjUifQ==",
+            "developerName": "searchtest",
+            "typeElementId": null,
+            "order": 0,
+            "properties": [
+                {
+                    "typeElementPropertyId": null,
+                    "developerName": "id",
+                    "contentType": "ContentNumber",
+                    "contentValue": "5",
+                    "contentFormat": null,
+                    "objectData": []
+                },
+                {
+                    "typeElementPropertyId": null,
+                    "developerName": "col_char",
+                    "contentType": "ContentString",
+                    "contentValue": "xxxx",
+                    "contentFormat": null,
+                    "objectData": []
+                },
+                {
+                    "typeElementPropertyId": null,
+                    "developerName": "col_nchar",
+                    "contentType": "ContentString",
+                    "contentValue": "xxxx",
+                    "contentFormat": null,
+                    "objectData": []
+                },
+                {
+                    "typeElementPropertyId": null,
+                    "developerName": "col_varchar",
+                    "contentType": "ContentString",
+                    "contentValue": "xxxx",
+                    "contentFormat": null,
+                    "objectData": []
+                },
+                {
+                    "typeElementPropertyId": null,
+                    "developerName": "col_nvarchar",
+                    "contentType": "ContentString",
+                    "contentValue": "xxxx",
+                    "contentFormat": null,
+                    "objectData": []
+                },
+                {
+                    "typeElementPropertyId": null,
+                    "developerName": "col_text",
+                    "contentType": "ContentString",
+                    "contentValue": "eeee",
+                    "contentFormat": null,
+                    "objectData": []
+                },
+                {
+                    "typeElementPropertyId": null,
+                    "developerName": "col_ntext",
+                    "contentType": "ContentString",
+                    "contentValue": "xxxx",
+                    "contentFormat": null,
+                    "objectData": []
+                }
+            ],
+            "isSelected": false
+        },
+        {
+            "internalId": null,
+            "externalId": "eyJpZCI6IjYifQ==",
+            "developerName": "searchtest",
+            "typeElementId": null,
+            "order": 0,
+            "properties": [
+                {
+                    "typeElementPropertyId": null,
+                    "developerName": "id",
+                    "contentType": "ContentNumber",
+                    "contentValue": "6",
+                    "contentFormat": null,
+                    "objectData": []
+                },
+                {
+                    "typeElementPropertyId": null,
+                    "developerName": "col_char",
+                    "contentType": "ContentString",
+                    "contentValue": "xxxx",
+                    "contentFormat": null,
+                    "objectData": []
+                },
+                {
+                    "typeElementPropertyId": null,
+                    "developerName": "col_nchar",
+                    "contentType": "ContentString",
+                    "contentValue": "xxxx",
+                    "contentFormat": null,
+                    "objectData": []
+                },
+                {
+                    "typeElementPropertyId": null,
+                    "developerName": "col_varchar",
+                    "contentType": "ContentString",
+                    "contentValue": "xxxx",
+                    "contentFormat": null,
+                    "objectData": []
+                },
+                {
+                    "typeElementPropertyId": null,
+                    "developerName": "col_nvarchar",
+                    "contentType": "ContentString",
+                    "contentValue": "xxxx",
+                    "contentFormat": null,
+                    "objectData": []
+                },
+                {
+                    "typeElementPropertyId": null,
+                    "developerName": "col_text",
+                    "contentType": "ContentString",
+                    "contentValue": "xxxx",
+                    "contentFormat": null,
+                    "objectData": []
+                },
+                {
+                    "typeElementPropertyId": null,
+                    "developerName": "col_ntext",
+                    "contentType": "ContentString",
+                    "contentValue": "ffff",
+                    "contentFormat": null,
+                    "objectData": []
+                }
+            ],
+            "isSelected": false
+        },
+        {
+            "internalId": null,
+            "externalId": "eyJpZCI6IjcifQ==",
+            "developerName": "searchtest",
+            "typeElementId": null,
+            "order": 0,
+            "properties": [
+                {
+                    "typeElementPropertyId": null,
+                    "developerName": "id",
+                    "contentType": "ContentNumber",
+                    "contentValue": "7",
+                    "contentFormat": null,
+                    "objectData": []
+                },
+                {
+                    "typeElementPropertyId": null,
+                    "developerName": "col_char",
+                    "contentType": "ContentString",
+                    "contentValue": "zzzz",
+                    "contentFormat": null,
+                    "objectData": []
+                },
+                {
+                    "typeElementPropertyId": null,
+                    "developerName": "col_nchar",
+                    "contentType": "ContentString",
+                    "contentValue": "zzzz",
+                    "contentFormat": null,
+                    "objectData": []
+                },
+                {
+                    "typeElementPropertyId": null,
+                    "developerName": "col_varchar",
+                    "contentType": "ContentString",
+                    "contentValue": "zzzz",
+                    "contentFormat": null,
+                    "objectData": []
+                },
+                {
+                    "typeElementPropertyId": null,
+                    "developerName": "col_nvarchar",
+                    "contentType": "ContentString",
+                    "contentValue": "zzzz",
+                    "contentFormat": null,
+                    "objectData": []
+                },
+                {
+                    "typeElementPropertyId": null,
+                    "developerName": "col_text",
+                    "contentType": "ContentString",
+                    "contentValue": "zzzz",
+                    "contentFormat": null,
+                    "objectData": []
+                },
+                {
+                    "typeElementPropertyId": null,
+                    "developerName": "col_ntext",
+                    "contentType": "ContentString",
+                    "contentValue": "zzzz",
+                    "contentFormat": null,
+                    "objectData": []
+                }
+            ],
+            "isSelected": false
+        }
+    ]
+}

--- a/src/test/resources/suites/sqlserver/search/char-request.json
+++ b/src/test/resources/suites/sqlserver/search/char-request.json
@@ -1,0 +1,160 @@
+{
+    "stateId": null,
+    "token": null,
+    "typeElementBindingId": null,
+    "authorization": {
+        "users": null,
+        "groups": null,
+        "runningAuthenticationId": null,
+        "globalAuthenticationType": "PUBLIC"
+    },
+    "configurationValues": [
+        {
+            "valueElementId": null,
+            "typeElementId": null,
+            "typeElementPropertyId": null,
+            "developerName": "Password",
+            "typeElementDeveloperName": null,
+            "typeElementPropertyDeveloperName": null,
+            "contentValue": "{{password}}",
+            "contentType": "ContentPassword",
+            "objectData": null
+        },
+        {
+            "valueElementId": null,
+            "typeElementId": null,
+            "typeElementPropertyId": null,
+            "developerName": "Database Type",
+            "typeElementDeveloperName": null,
+            "typeElementPropertyDeveloperName": null,
+            "contentValue": "{{databaseType}}",
+            "contentType": "ContentString",
+            "objectData": null
+        },
+        {
+            "valueElementId": null,
+            "typeElementId": null,
+            "typeElementPropertyId": null,
+            "developerName": "Database Name",
+            "typeElementDeveloperName": null,
+            "typeElementPropertyDeveloperName": null,
+            "contentValue": "{{databaseName}}",
+            "contentType": "ContentString",
+            "objectData": null
+        },
+        {
+            "valueElementId": null,
+            "typeElementId": null,
+            "typeElementPropertyId": null,
+            "developerName": "Port",
+            "typeElementDeveloperName": null,
+            "typeElementPropertyDeveloperName": null,
+            "contentValue": "{{port}}",
+            "contentType": "ContentNumber",
+            "objectData": null
+        },
+        {
+            "valueElementId": null,
+            "typeElementId": null,
+            "typeElementPropertyId": null,
+            "developerName": "Host",
+            "typeElementDeveloperName": null,
+            "typeElementPropertyDeveloperName": null,
+            "contentValue": "{{host}}",
+            "contentType": "ContentString",
+            "objectData": null
+        },
+        {
+            "valueElementId": null,
+            "typeElementId": null,
+            "typeElementPropertyId": null,
+            "developerName": "Database Schema",
+            "typeElementDeveloperName": null,
+            "typeElementPropertyDeveloperName": null,
+            "contentValue": "{{schema}}",
+            "contentType": "ContentString",
+            "objectData": null
+        },
+        {
+            "valueElementId": null,
+            "typeElementId": null,
+            "typeElementPropertyId": null,
+            "developerName": "Username",
+            "typeElementDeveloperName": null,
+            "typeElementPropertyDeveloperName": null,
+            "contentValue": "{{userName}}",
+            "contentType": "ContentString",
+            "objectData": null
+        },
+        {
+            "valueElementId": null,
+            "typeElementId": null,
+            "typeElementPropertyId": null,
+            "developerName": "No SSL",
+            "typeElementDeveloperName": null,
+            "typeElementPropertyDeveloperName": null,
+            "contentValue": "true",
+            "contentType": null,
+            "objectData": null
+        }
+    ],
+    "command": null,
+    "culture": {
+        "id": null,
+        "developerName": null,
+        "developerSummary": null,
+        "brand": null,
+        "language": "EN",
+        "country": "USA",
+        "variant": null
+    },
+    "listFilter": {
+        "id": null,
+        "filterByProvidedObjects": false,
+        "orderByPropertyDeveloperName": "id",
+        "orderByDirectionType": "",
+        "orderBy": null,
+        "limit": 0,
+        "offset": 0,
+        "search": "aa",
+        "searchCriteria": null,
+        "comparisonType": "OR",
+        "where": null,
+        "listFilters": null
+    },
+    "objectDataType": {
+        "typeElementId": "737809a7-5825-4b04-8d38-b271963732e5",
+        "developerName": "searchtest",
+        "properties": [
+            {
+                "developerName": "id",
+                "list": null
+            },
+            {
+                "developerName": "col_char",
+                "list": null
+            },
+            {
+                "developerName": "col_nchar",
+                "list": null
+            },
+            {
+                "developerName": "col_varchar",
+                "list": null
+            },
+            {
+                "developerName": "col_nvarchar",
+                "list": null
+            },
+            {
+                "developerName": "col_text",
+                "list": null
+            },
+            {
+                "developerName": "col_ntext",
+                "list": null
+            }
+        ]
+    },
+    "objectData": null
+}

--- a/src/test/resources/suites/sqlserver/search/char-response.json
+++ b/src/test/resources/suites/sqlserver/search/char-response.json
@@ -1,0 +1,72 @@
+{
+    "culture": null,
+    "hasMoreResults": false,
+    "objectData": [
+        {
+            "internalId": null,
+            "externalId": "eyJpZCI6IjEifQ==",
+            "developerName": "searchtest",
+            "typeElementId": null,
+            "order": 0,
+            "properties": [
+                {
+                    "typeElementPropertyId": null,
+                    "developerName": "id",
+                    "contentType": "ContentNumber",
+                    "contentValue": "1",
+                    "contentFormat": null,
+                    "objectData": []
+                },
+                {
+                    "typeElementPropertyId": null,
+                    "developerName": "col_char",
+                    "contentType": "ContentString",
+                    "contentValue": "aaaa",
+                    "contentFormat": null,
+                    "objectData": []
+                },
+                {
+                    "typeElementPropertyId": null,
+                    "developerName": "col_nchar",
+                    "contentType": "ContentString",
+                    "contentValue": "xxxx",
+                    "contentFormat": null,
+                    "objectData": []
+                },
+                {
+                    "typeElementPropertyId": null,
+                    "developerName": "col_varchar",
+                    "contentType": "ContentString",
+                    "contentValue": "xxxx",
+                    "contentFormat": null,
+                    "objectData": []
+                },
+                {
+                    "typeElementPropertyId": null,
+                    "developerName": "col_nvarchar",
+                    "contentType": "ContentString",
+                    "contentValue": "xxxx",
+                    "contentFormat": null,
+                    "objectData": []
+                },
+                {
+                    "typeElementPropertyId": null,
+                    "developerName": "col_text",
+                    "contentType": "ContentString",
+                    "contentValue": "xxxx",
+                    "contentFormat": null,
+                    "objectData": []
+                },
+                {
+                    "typeElementPropertyId": null,
+                    "developerName": "col_ntext",
+                    "contentType": "ContentString",
+                    "contentValue": "xxxx",
+                    "contentFormat": null,
+                    "objectData": []
+                }
+            ],
+            "isSelected": false
+        }
+    ]
+}

--- a/src/test/resources/suites/sqlserver/search/nchar-request.json
+++ b/src/test/resources/suites/sqlserver/search/nchar-request.json
@@ -1,0 +1,160 @@
+{
+    "stateId": null,
+    "token": null,
+    "typeElementBindingId": null,
+    "authorization": {
+        "users": null,
+        "groups": null,
+        "runningAuthenticationId": null,
+        "globalAuthenticationType": "PUBLIC"
+    },
+    "configurationValues": [
+        {
+            "valueElementId": null,
+            "typeElementId": null,
+            "typeElementPropertyId": null,
+            "developerName": "Password",
+            "typeElementDeveloperName": null,
+            "typeElementPropertyDeveloperName": null,
+            "contentValue": "{{password}}",
+            "contentType": "ContentPassword",
+            "objectData": null
+        },
+        {
+            "valueElementId": null,
+            "typeElementId": null,
+            "typeElementPropertyId": null,
+            "developerName": "Database Type",
+            "typeElementDeveloperName": null,
+            "typeElementPropertyDeveloperName": null,
+            "contentValue": "{{databaseType}}",
+            "contentType": "ContentString",
+            "objectData": null
+        },
+        {
+            "valueElementId": null,
+            "typeElementId": null,
+            "typeElementPropertyId": null,
+            "developerName": "Database Name",
+            "typeElementDeveloperName": null,
+            "typeElementPropertyDeveloperName": null,
+            "contentValue": "{{databaseName}}",
+            "contentType": "ContentString",
+            "objectData": null
+        },
+        {
+            "valueElementId": null,
+            "typeElementId": null,
+            "typeElementPropertyId": null,
+            "developerName": "Port",
+            "typeElementDeveloperName": null,
+            "typeElementPropertyDeveloperName": null,
+            "contentValue": "{{port}}",
+            "contentType": "ContentNumber",
+            "objectData": null
+        },
+        {
+            "valueElementId": null,
+            "typeElementId": null,
+            "typeElementPropertyId": null,
+            "developerName": "Host",
+            "typeElementDeveloperName": null,
+            "typeElementPropertyDeveloperName": null,
+            "contentValue": "{{host}}",
+            "contentType": "ContentString",
+            "objectData": null
+        },
+        {
+            "valueElementId": null,
+            "typeElementId": null,
+            "typeElementPropertyId": null,
+            "developerName": "Database Schema",
+            "typeElementDeveloperName": null,
+            "typeElementPropertyDeveloperName": null,
+            "contentValue": "{{schema}}",
+            "contentType": "ContentString",
+            "objectData": null
+        },
+        {
+            "valueElementId": null,
+            "typeElementId": null,
+            "typeElementPropertyId": null,
+            "developerName": "Username",
+            "typeElementDeveloperName": null,
+            "typeElementPropertyDeveloperName": null,
+            "contentValue": "{{userName}}",
+            "contentType": "ContentString",
+            "objectData": null
+        },
+        {
+            "valueElementId": null,
+            "typeElementId": null,
+            "typeElementPropertyId": null,
+            "developerName": "No SSL",
+            "typeElementDeveloperName": null,
+            "typeElementPropertyDeveloperName": null,
+            "contentValue": "true",
+            "contentType": null,
+            "objectData": null
+        }
+    ],
+    "command": null,
+    "culture": {
+        "id": null,
+        "developerName": null,
+        "developerSummary": null,
+        "brand": null,
+        "language": "EN",
+        "country": "USA",
+        "variant": null
+    },
+    "listFilter": {
+        "id": null,
+        "filterByProvidedObjects": false,
+        "orderByPropertyDeveloperName": "id",
+        "orderByDirectionType": "",
+        "orderBy": null,
+        "limit": 0,
+        "offset": 0,
+        "search": "bb",
+        "searchCriteria": null,
+        "comparisonType": "OR",
+        "where": null,
+        "listFilters": null
+    },
+    "objectDataType": {
+        "typeElementId": "737809a7-5825-4b04-8d38-b271963732e5",
+        "developerName": "searchtest",
+        "properties": [
+            {
+                "developerName": "id",
+                "list": null
+            },
+            {
+                "developerName": "col_char",
+                "list": null
+            },
+            {
+                "developerName": "col_nchar",
+                "list": null
+            },
+            {
+                "developerName": "col_varchar",
+                "list": null
+            },
+            {
+                "developerName": "col_nvarchar",
+                "list": null
+            },
+            {
+                "developerName": "col_text",
+                "list": null
+            },
+            {
+                "developerName": "col_ntext",
+                "list": null
+            }
+        ]
+    },
+    "objectData": null
+}

--- a/src/test/resources/suites/sqlserver/search/nchar-response.json
+++ b/src/test/resources/suites/sqlserver/search/nchar-response.json
@@ -1,0 +1,72 @@
+{
+    "culture": null,
+    "hasMoreResults": false,
+    "objectData": [
+        {
+            "internalId": null,
+            "externalId": "eyJpZCI6IjIifQ==",
+            "developerName": "searchtest",
+            "typeElementId": null,
+            "order": 0,
+            "properties": [
+                {
+                    "typeElementPropertyId": null,
+                    "developerName": "id",
+                    "contentType": "ContentNumber",
+                    "contentValue": "2",
+                    "contentFormat": null,
+                    "objectData": []
+                },
+                {
+                    "typeElementPropertyId": null,
+                    "developerName": "col_char",
+                    "contentType": "ContentString",
+                    "contentValue": "xxxx",
+                    "contentFormat": null,
+                    "objectData": []
+                },
+                {
+                    "typeElementPropertyId": null,
+                    "developerName": "col_nchar",
+                    "contentType": "ContentString",
+                    "contentValue": "bbbb",
+                    "contentFormat": null,
+                    "objectData": []
+                },
+                {
+                    "typeElementPropertyId": null,
+                    "developerName": "col_varchar",
+                    "contentType": "ContentString",
+                    "contentValue": "xxxx",
+                    "contentFormat": null,
+                    "objectData": []
+                },
+                {
+                    "typeElementPropertyId": null,
+                    "developerName": "col_nvarchar",
+                    "contentType": "ContentString",
+                    "contentValue": "xxxx",
+                    "contentFormat": null,
+                    "objectData": []
+                },
+                {
+                    "typeElementPropertyId": null,
+                    "developerName": "col_text",
+                    "contentType": "ContentString",
+                    "contentValue": "xxxx",
+                    "contentFormat": null,
+                    "objectData": []
+                },
+                {
+                    "typeElementPropertyId": null,
+                    "developerName": "col_ntext",
+                    "contentType": "ContentString",
+                    "contentValue": "xxxx",
+                    "contentFormat": null,
+                    "objectData": []
+                }
+            ],
+            "isSelected": false
+        }
+    ]
+}

--- a/src/test/resources/suites/sqlserver/search/noresults-request.json
+++ b/src/test/resources/suites/sqlserver/search/noresults-request.json
@@ -1,0 +1,160 @@
+{
+    "stateId": null,
+    "token": null,
+    "typeElementBindingId": null,
+    "authorization": {
+        "users": null,
+        "groups": null,
+        "runningAuthenticationId": null,
+        "globalAuthenticationType": "PUBLIC"
+    },
+    "configurationValues": [
+        {
+            "valueElementId": null,
+            "typeElementId": null,
+            "typeElementPropertyId": null,
+            "developerName": "Password",
+            "typeElementDeveloperName": null,
+            "typeElementPropertyDeveloperName": null,
+            "contentValue": "{{password}}",
+            "contentType": "ContentPassword",
+            "objectData": null
+        },
+        {
+            "valueElementId": null,
+            "typeElementId": null,
+            "typeElementPropertyId": null,
+            "developerName": "Database Type",
+            "typeElementDeveloperName": null,
+            "typeElementPropertyDeveloperName": null,
+            "contentValue": "{{databaseType}}",
+            "contentType": "ContentString",
+            "objectData": null
+        },
+        {
+            "valueElementId": null,
+            "typeElementId": null,
+            "typeElementPropertyId": null,
+            "developerName": "Database Name",
+            "typeElementDeveloperName": null,
+            "typeElementPropertyDeveloperName": null,
+            "contentValue": "{{databaseName}}",
+            "contentType": "ContentString",
+            "objectData": null
+        },
+        {
+            "valueElementId": null,
+            "typeElementId": null,
+            "typeElementPropertyId": null,
+            "developerName": "Port",
+            "typeElementDeveloperName": null,
+            "typeElementPropertyDeveloperName": null,
+            "contentValue": "{{port}}",
+            "contentType": "ContentNumber",
+            "objectData": null
+        },
+        {
+            "valueElementId": null,
+            "typeElementId": null,
+            "typeElementPropertyId": null,
+            "developerName": "Host",
+            "typeElementDeveloperName": null,
+            "typeElementPropertyDeveloperName": null,
+            "contentValue": "{{host}}",
+            "contentType": "ContentString",
+            "objectData": null
+        },
+        {
+            "valueElementId": null,
+            "typeElementId": null,
+            "typeElementPropertyId": null,
+            "developerName": "Database Schema",
+            "typeElementDeveloperName": null,
+            "typeElementPropertyDeveloperName": null,
+            "contentValue": "{{schema}}",
+            "contentType": "ContentString",
+            "objectData": null
+        },
+        {
+            "valueElementId": null,
+            "typeElementId": null,
+            "typeElementPropertyId": null,
+            "developerName": "Username",
+            "typeElementDeveloperName": null,
+            "typeElementPropertyDeveloperName": null,
+            "contentValue": "{{userName}}",
+            "contentType": "ContentString",
+            "objectData": null
+        },
+        {
+            "valueElementId": null,
+            "typeElementId": null,
+            "typeElementPropertyId": null,
+            "developerName": "No SSL",
+            "typeElementDeveloperName": null,
+            "typeElementPropertyDeveloperName": null,
+            "contentValue": "true",
+            "contentType": null,
+            "objectData": null
+        }
+    ],
+    "command": null,
+    "culture": {
+        "id": null,
+        "developerName": null,
+        "developerSummary": null,
+        "brand": null,
+        "language": "EN",
+        "country": "USA",
+        "variant": null
+    },
+    "listFilter": {
+        "id": null,
+        "filterByProvidedObjects": false,
+        "orderByPropertyDeveloperName": "id",
+        "orderByDirectionType": "",
+        "orderBy": null,
+        "limit": 0,
+        "offset": 0,
+        "search": "noresults",
+        "searchCriteria": null,
+        "comparisonType": "OR",
+        "where": null,
+        "listFilters": null
+    },
+    "objectDataType": {
+        "typeElementId": "737809a7-5825-4b04-8d38-b271963732e5",
+        "developerName": "searchtest",
+        "properties": [
+            {
+                "developerName": "id",
+                "list": null
+            },
+            {
+                "developerName": "col_char",
+                "list": null
+            },
+            {
+                "developerName": "col_nchar",
+                "list": null
+            },
+            {
+                "developerName": "col_varchar",
+                "list": null
+            },
+            {
+                "developerName": "col_nvarchar",
+                "list": null
+            },
+            {
+                "developerName": "col_text",
+                "list": null
+            },
+            {
+                "developerName": "col_ntext",
+                "list": null
+            }
+        ]
+    },
+    "objectData": null
+}

--- a/src/test/resources/suites/sqlserver/search/noresults-response.json
+++ b/src/test/resources/suites/sqlserver/search/noresults-response.json
@@ -1,0 +1,5 @@
+{
+    "culture": null,
+    "hasMoreResults": false,
+    "objectData": []
+}

--- a/src/test/resources/suites/sqlserver/search/ntext-request.json
+++ b/src/test/resources/suites/sqlserver/search/ntext-request.json
@@ -1,0 +1,160 @@
+{
+    "stateId": null,
+    "token": null,
+    "typeElementBindingId": null,
+    "authorization": {
+        "users": null,
+        "groups": null,
+        "runningAuthenticationId": null,
+        "globalAuthenticationType": "PUBLIC"
+    },
+    "configurationValues": [
+        {
+            "valueElementId": null,
+            "typeElementId": null,
+            "typeElementPropertyId": null,
+            "developerName": "Password",
+            "typeElementDeveloperName": null,
+            "typeElementPropertyDeveloperName": null,
+            "contentValue": "{{password}}",
+            "contentType": "ContentPassword",
+            "objectData": null
+        },
+        {
+            "valueElementId": null,
+            "typeElementId": null,
+            "typeElementPropertyId": null,
+            "developerName": "Database Type",
+            "typeElementDeveloperName": null,
+            "typeElementPropertyDeveloperName": null,
+            "contentValue": "{{databaseType}}",
+            "contentType": "ContentString",
+            "objectData": null
+        },
+        {
+            "valueElementId": null,
+            "typeElementId": null,
+            "typeElementPropertyId": null,
+            "developerName": "Database Name",
+            "typeElementDeveloperName": null,
+            "typeElementPropertyDeveloperName": null,
+            "contentValue": "{{databaseName}}",
+            "contentType": "ContentString",
+            "objectData": null
+        },
+        {
+            "valueElementId": null,
+            "typeElementId": null,
+            "typeElementPropertyId": null,
+            "developerName": "Port",
+            "typeElementDeveloperName": null,
+            "typeElementPropertyDeveloperName": null,
+            "contentValue": "{{port}}",
+            "contentType": "ContentNumber",
+            "objectData": null
+        },
+        {
+            "valueElementId": null,
+            "typeElementId": null,
+            "typeElementPropertyId": null,
+            "developerName": "Host",
+            "typeElementDeveloperName": null,
+            "typeElementPropertyDeveloperName": null,
+            "contentValue": "{{host}}",
+            "contentType": "ContentString",
+            "objectData": null
+        },
+        {
+            "valueElementId": null,
+            "typeElementId": null,
+            "typeElementPropertyId": null,
+            "developerName": "Database Schema",
+            "typeElementDeveloperName": null,
+            "typeElementPropertyDeveloperName": null,
+            "contentValue": "{{schema}}",
+            "contentType": "ContentString",
+            "objectData": null
+        },
+        {
+            "valueElementId": null,
+            "typeElementId": null,
+            "typeElementPropertyId": null,
+            "developerName": "Username",
+            "typeElementDeveloperName": null,
+            "typeElementPropertyDeveloperName": null,
+            "contentValue": "{{userName}}",
+            "contentType": "ContentString",
+            "objectData": null
+        },
+        {
+            "valueElementId": null,
+            "typeElementId": null,
+            "typeElementPropertyId": null,
+            "developerName": "No SSL",
+            "typeElementDeveloperName": null,
+            "typeElementPropertyDeveloperName": null,
+            "contentValue": "true",
+            "contentType": null,
+            "objectData": null
+        }
+    ],
+    "command": null,
+    "culture": {
+        "id": null,
+        "developerName": null,
+        "developerSummary": null,
+        "brand": null,
+        "language": "EN",
+        "country": "USA",
+        "variant": null
+    },
+    "listFilter": {
+        "id": null,
+        "filterByProvidedObjects": false,
+        "orderByPropertyDeveloperName": "id",
+        "orderByDirectionType": "",
+        "orderBy": null,
+        "limit": 0,
+        "offset": 0,
+        "search": "ff",
+        "searchCriteria": null,
+        "comparisonType": "OR",
+        "where": null,
+        "listFilters": null
+    },
+    "objectDataType": {
+        "typeElementId": "737809a7-5825-4b04-8d38-b271963732e5",
+        "developerName": "searchtest",
+        "properties": [
+            {
+                "developerName": "id",
+                "list": null
+            },
+            {
+                "developerName": "col_char",
+                "list": null
+            },
+            {
+                "developerName": "col_nchar",
+                "list": null
+            },
+            {
+                "developerName": "col_varchar",
+                "list": null
+            },
+            {
+                "developerName": "col_nvarchar",
+                "list": null
+            },
+            {
+                "developerName": "col_text",
+                "list": null
+            },
+            {
+                "developerName": "col_ntext",
+                "list": null
+            }
+        ]
+    },
+    "objectData": null
+}

--- a/src/test/resources/suites/sqlserver/search/ntext-response.json
+++ b/src/test/resources/suites/sqlserver/search/ntext-response.json
@@ -1,0 +1,72 @@
+{
+    "culture": null,
+    "hasMoreResults": false,
+    "objectData": [
+        {
+            "internalId": null,
+            "externalId": "eyJpZCI6IjYifQ==",
+            "developerName": "searchtest",
+            "typeElementId": null,
+            "order": 0,
+            "properties": [
+                {
+                    "typeElementPropertyId": null,
+                    "developerName": "id",
+                    "contentType": "ContentNumber",
+                    "contentValue": "6",
+                    "contentFormat": null,
+                    "objectData": []
+                },
+                {
+                    "typeElementPropertyId": null,
+                    "developerName": "col_char",
+                    "contentType": "ContentString",
+                    "contentValue": "xxxx",
+                    "contentFormat": null,
+                    "objectData": []
+                },
+                {
+                    "typeElementPropertyId": null,
+                    "developerName": "col_nchar",
+                    "contentType": "ContentString",
+                    "contentValue": "xxxx",
+                    "contentFormat": null,
+                    "objectData": []
+                },
+                {
+                    "typeElementPropertyId": null,
+                    "developerName": "col_varchar",
+                    "contentType": "ContentString",
+                    "contentValue": "xxxx",
+                    "contentFormat": null,
+                    "objectData": []
+                },
+                {
+                    "typeElementPropertyId": null,
+                    "developerName": "col_nvarchar",
+                    "contentType": "ContentString",
+                    "contentValue": "xxxx",
+                    "contentFormat": null,
+                    "objectData": []
+                },
+                {
+                    "typeElementPropertyId": null,
+                    "developerName": "col_text",
+                    "contentType": "ContentString",
+                    "contentValue": "xxxx",
+                    "contentFormat": null,
+                    "objectData": []
+                },
+                {
+                    "typeElementPropertyId": null,
+                    "developerName": "col_ntext",
+                    "contentType": "ContentString",
+                    "contentValue": "ffff",
+                    "contentFormat": null,
+                    "objectData": []
+                }
+            ],
+            "isSelected": false
+        }
+    ]
+}

--- a/src/test/resources/suites/sqlserver/search/nvarchar-request.json
+++ b/src/test/resources/suites/sqlserver/search/nvarchar-request.json
@@ -1,0 +1,160 @@
+{
+    "stateId": null,
+    "token": null,
+    "typeElementBindingId": null,
+    "authorization": {
+        "users": null,
+        "groups": null,
+        "runningAuthenticationId": null,
+        "globalAuthenticationType": "PUBLIC"
+    },
+    "configurationValues": [
+        {
+            "valueElementId": null,
+            "typeElementId": null,
+            "typeElementPropertyId": null,
+            "developerName": "Password",
+            "typeElementDeveloperName": null,
+            "typeElementPropertyDeveloperName": null,
+            "contentValue": "{{password}}",
+            "contentType": "ContentPassword",
+            "objectData": null
+        },
+        {
+            "valueElementId": null,
+            "typeElementId": null,
+            "typeElementPropertyId": null,
+            "developerName": "Database Type",
+            "typeElementDeveloperName": null,
+            "typeElementPropertyDeveloperName": null,
+            "contentValue": "{{databaseType}}",
+            "contentType": "ContentString",
+            "objectData": null
+        },
+        {
+            "valueElementId": null,
+            "typeElementId": null,
+            "typeElementPropertyId": null,
+            "developerName": "Database Name",
+            "typeElementDeveloperName": null,
+            "typeElementPropertyDeveloperName": null,
+            "contentValue": "{{databaseName}}",
+            "contentType": "ContentString",
+            "objectData": null
+        },
+        {
+            "valueElementId": null,
+            "typeElementId": null,
+            "typeElementPropertyId": null,
+            "developerName": "Port",
+            "typeElementDeveloperName": null,
+            "typeElementPropertyDeveloperName": null,
+            "contentValue": "{{port}}",
+            "contentType": "ContentNumber",
+            "objectData": null
+        },
+        {
+            "valueElementId": null,
+            "typeElementId": null,
+            "typeElementPropertyId": null,
+            "developerName": "Host",
+            "typeElementDeveloperName": null,
+            "typeElementPropertyDeveloperName": null,
+            "contentValue": "{{host}}",
+            "contentType": "ContentString",
+            "objectData": null
+        },
+        {
+            "valueElementId": null,
+            "typeElementId": null,
+            "typeElementPropertyId": null,
+            "developerName": "Database Schema",
+            "typeElementDeveloperName": null,
+            "typeElementPropertyDeveloperName": null,
+            "contentValue": "{{schema}}",
+            "contentType": "ContentString",
+            "objectData": null
+        },
+        {
+            "valueElementId": null,
+            "typeElementId": null,
+            "typeElementPropertyId": null,
+            "developerName": "Username",
+            "typeElementDeveloperName": null,
+            "typeElementPropertyDeveloperName": null,
+            "contentValue": "{{userName}}",
+            "contentType": "ContentString",
+            "objectData": null
+        },
+        {
+            "valueElementId": null,
+            "typeElementId": null,
+            "typeElementPropertyId": null,
+            "developerName": "No SSL",
+            "typeElementDeveloperName": null,
+            "typeElementPropertyDeveloperName": null,
+            "contentValue": "true",
+            "contentType": null,
+            "objectData": null
+        }
+    ],
+    "command": null,
+    "culture": {
+        "id": null,
+        "developerName": null,
+        "developerSummary": null,
+        "brand": null,
+        "language": "EN",
+        "country": "USA",
+        "variant": null
+    },
+    "listFilter": {
+        "id": null,
+        "filterByProvidedObjects": false,
+        "orderByPropertyDeveloperName": "id",
+        "orderByDirectionType": "",
+        "orderBy": null,
+        "limit": 0,
+        "offset": 0,
+        "search": "dd",
+        "searchCriteria": null,
+        "comparisonType": "OR",
+        "where": null,
+        "listFilters": null
+    },
+    "objectDataType": {
+        "typeElementId": "737809a7-5825-4b04-8d38-b271963732e5",
+        "developerName": "searchtest",
+        "properties": [
+            {
+                "developerName": "id",
+                "list": null
+            },
+            {
+                "developerName": "col_char",
+                "list": null
+            },
+            {
+                "developerName": "col_nchar",
+                "list": null
+            },
+            {
+                "developerName": "col_varchar",
+                "list": null
+            },
+            {
+                "developerName": "col_nvarchar",
+                "list": null
+            },
+            {
+                "developerName": "col_text",
+                "list": null
+            },
+            {
+                "developerName": "col_ntext",
+                "list": null
+            }
+        ]
+    },
+    "objectData": null
+}

--- a/src/test/resources/suites/sqlserver/search/nvarchar-response.json
+++ b/src/test/resources/suites/sqlserver/search/nvarchar-response.json
@@ -1,0 +1,72 @@
+{
+    "culture": null,
+    "hasMoreResults": false,
+    "objectData": [
+        {
+            "internalId": null,
+            "externalId": "eyJpZCI6IjQifQ==",
+            "developerName": "searchtest",
+            "typeElementId": null,
+            "order": 0,
+            "properties": [
+                {
+                    "typeElementPropertyId": null,
+                    "developerName": "id",
+                    "contentType": "ContentNumber",
+                    "contentValue": "4",
+                    "contentFormat": null,
+                    "objectData": []
+                },
+                {
+                    "typeElementPropertyId": null,
+                    "developerName": "col_char",
+                    "contentType": "ContentString",
+                    "contentValue": "xxxx",
+                    "contentFormat": null,
+                    "objectData": []
+                },
+                {
+                    "typeElementPropertyId": null,
+                    "developerName": "col_nchar",
+                    "contentType": "ContentString",
+                    "contentValue": "xxxx",
+                    "contentFormat": null,
+                    "objectData": []
+                },
+                {
+                    "typeElementPropertyId": null,
+                    "developerName": "col_varchar",
+                    "contentType": "ContentString",
+                    "contentValue": "xxxx",
+                    "contentFormat": null,
+                    "objectData": []
+                },
+                {
+                    "typeElementPropertyId": null,
+                    "developerName": "col_nvarchar",
+                    "contentType": "ContentString",
+                    "contentValue": "dddd",
+                    "contentFormat": null,
+                    "objectData": []
+                },
+                {
+                    "typeElementPropertyId": null,
+                    "developerName": "col_text",
+                    "contentType": "ContentString",
+                    "contentValue": "xxxx",
+                    "contentFormat": null,
+                    "objectData": []
+                },
+                {
+                    "typeElementPropertyId": null,
+                    "developerName": "col_ntext",
+                    "contentType": "ContentString",
+                    "contentValue": "xxxx",
+                    "contentFormat": null,
+                    "objectData": []
+                }
+            ],
+            "isSelected": false
+        }
+    ]
+}

--- a/src/test/resources/suites/sqlserver/search/text-request.json
+++ b/src/test/resources/suites/sqlserver/search/text-request.json
@@ -1,0 +1,160 @@
+{
+    "stateId": null,
+    "token": null,
+    "typeElementBindingId": null,
+    "authorization": {
+        "users": null,
+        "groups": null,
+        "runningAuthenticationId": null,
+        "globalAuthenticationType": "PUBLIC"
+    },
+    "configurationValues": [
+        {
+            "valueElementId": null,
+            "typeElementId": null,
+            "typeElementPropertyId": null,
+            "developerName": "Password",
+            "typeElementDeveloperName": null,
+            "typeElementPropertyDeveloperName": null,
+            "contentValue": "{{password}}",
+            "contentType": "ContentPassword",
+            "objectData": null
+        },
+        {
+            "valueElementId": null,
+            "typeElementId": null,
+            "typeElementPropertyId": null,
+            "developerName": "Database Type",
+            "typeElementDeveloperName": null,
+            "typeElementPropertyDeveloperName": null,
+            "contentValue": "{{databaseType}}",
+            "contentType": "ContentString",
+            "objectData": null
+        },
+        {
+            "valueElementId": null,
+            "typeElementId": null,
+            "typeElementPropertyId": null,
+            "developerName": "Database Name",
+            "typeElementDeveloperName": null,
+            "typeElementPropertyDeveloperName": null,
+            "contentValue": "{{databaseName}}",
+            "contentType": "ContentString",
+            "objectData": null
+        },
+        {
+            "valueElementId": null,
+            "typeElementId": null,
+            "typeElementPropertyId": null,
+            "developerName": "Port",
+            "typeElementDeveloperName": null,
+            "typeElementPropertyDeveloperName": null,
+            "contentValue": "{{port}}",
+            "contentType": "ContentNumber",
+            "objectData": null
+        },
+        {
+            "valueElementId": null,
+            "typeElementId": null,
+            "typeElementPropertyId": null,
+            "developerName": "Host",
+            "typeElementDeveloperName": null,
+            "typeElementPropertyDeveloperName": null,
+            "contentValue": "{{host}}",
+            "contentType": "ContentString",
+            "objectData": null
+        },
+        {
+            "valueElementId": null,
+            "typeElementId": null,
+            "typeElementPropertyId": null,
+            "developerName": "Database Schema",
+            "typeElementDeveloperName": null,
+            "typeElementPropertyDeveloperName": null,
+            "contentValue": "{{schema}}",
+            "contentType": "ContentString",
+            "objectData": null
+        },
+        {
+            "valueElementId": null,
+            "typeElementId": null,
+            "typeElementPropertyId": null,
+            "developerName": "Username",
+            "typeElementDeveloperName": null,
+            "typeElementPropertyDeveloperName": null,
+            "contentValue": "{{userName}}",
+            "contentType": "ContentString",
+            "objectData": null
+        },
+        {
+            "valueElementId": null,
+            "typeElementId": null,
+            "typeElementPropertyId": null,
+            "developerName": "No SSL",
+            "typeElementDeveloperName": null,
+            "typeElementPropertyDeveloperName": null,
+            "contentValue": "true",
+            "contentType": null,
+            "objectData": null
+        }
+    ],
+    "command": null,
+    "culture": {
+        "id": null,
+        "developerName": null,
+        "developerSummary": null,
+        "brand": null,
+        "language": "EN",
+        "country": "USA",
+        "variant": null
+    },
+    "listFilter": {
+        "id": null,
+        "filterByProvidedObjects": false,
+        "orderByPropertyDeveloperName": "id",
+        "orderByDirectionType": "",
+        "orderBy": null,
+        "limit": 0,
+        "offset": 0,
+        "search": "ee",
+        "searchCriteria": null,
+        "comparisonType": "OR",
+        "where": null,
+        "listFilters": null
+    },
+    "objectDataType": {
+        "typeElementId": "737809a7-5825-4b04-8d38-b271963732e5",
+        "developerName": "searchtest",
+        "properties": [
+            {
+                "developerName": "id",
+                "list": null
+            },
+            {
+                "developerName": "col_char",
+                "list": null
+            },
+            {
+                "developerName": "col_nchar",
+                "list": null
+            },
+            {
+                "developerName": "col_varchar",
+                "list": null
+            },
+            {
+                "developerName": "col_nvarchar",
+                "list": null
+            },
+            {
+                "developerName": "col_text",
+                "list": null
+            },
+            {
+                "developerName": "col_ntext",
+                "list": null
+            }
+        ]
+    },
+    "objectData": null
+}

--- a/src/test/resources/suites/sqlserver/search/text-response.json
+++ b/src/test/resources/suites/sqlserver/search/text-response.json
@@ -1,0 +1,72 @@
+{
+    "culture": null,
+    "hasMoreResults": false,
+    "objectData": [
+        {
+            "internalId": null,
+            "externalId": "eyJpZCI6IjUifQ==",
+            "developerName": "searchtest",
+            "typeElementId": null,
+            "order": 0,
+            "properties": [
+                {
+                    "typeElementPropertyId": null,
+                    "developerName": "id",
+                    "contentType": "ContentNumber",
+                    "contentValue": "5",
+                    "contentFormat": null,
+                    "objectData": []
+                },
+                {
+                    "typeElementPropertyId": null,
+                    "developerName": "col_char",
+                    "contentType": "ContentString",
+                    "contentValue": "xxxx",
+                    "contentFormat": null,
+                    "objectData": []
+                },
+                {
+                    "typeElementPropertyId": null,
+                    "developerName": "col_nchar",
+                    "contentType": "ContentString",
+                    "contentValue": "xxxx",
+                    "contentFormat": null,
+                    "objectData": []
+                },
+                {
+                    "typeElementPropertyId": null,
+                    "developerName": "col_varchar",
+                    "contentType": "ContentString",
+                    "contentValue": "xxxx",
+                    "contentFormat": null,
+                    "objectData": []
+                },
+                {
+                    "typeElementPropertyId": null,
+                    "developerName": "col_nvarchar",
+                    "contentType": "ContentString",
+                    "contentValue": "xxxx",
+                    "contentFormat": null,
+                    "objectData": []
+                },
+                {
+                    "typeElementPropertyId": null,
+                    "developerName": "col_text",
+                    "contentType": "ContentString",
+                    "contentValue": "eeee",
+                    "contentFormat": null,
+                    "objectData": []
+                },
+                {
+                    "typeElementPropertyId": null,
+                    "developerName": "col_ntext",
+                    "contentType": "ContentString",
+                    "contentValue": "xxxx",
+                    "contentFormat": null,
+                    "objectData": []
+                }
+            ],
+            "isSelected": false
+        }
+    ]
+}

--- a/src/test/resources/suites/sqlserver/search/varchar-request.json
+++ b/src/test/resources/suites/sqlserver/search/varchar-request.json
@@ -1,0 +1,160 @@
+{
+    "stateId": null,
+    "token": null,
+    "typeElementBindingId": null,
+    "authorization": {
+        "users": null,
+        "groups": null,
+        "runningAuthenticationId": null,
+        "globalAuthenticationType": "PUBLIC"
+    },
+    "configurationValues": [
+        {
+            "valueElementId": null,
+            "typeElementId": null,
+            "typeElementPropertyId": null,
+            "developerName": "Password",
+            "typeElementDeveloperName": null,
+            "typeElementPropertyDeveloperName": null,
+            "contentValue": "{{password}}",
+            "contentType": "ContentPassword",
+            "objectData": null
+        },
+        {
+            "valueElementId": null,
+            "typeElementId": null,
+            "typeElementPropertyId": null,
+            "developerName": "Database Type",
+            "typeElementDeveloperName": null,
+            "typeElementPropertyDeveloperName": null,
+            "contentValue": "{{databaseType}}",
+            "contentType": "ContentString",
+            "objectData": null
+        },
+        {
+            "valueElementId": null,
+            "typeElementId": null,
+            "typeElementPropertyId": null,
+            "developerName": "Database Name",
+            "typeElementDeveloperName": null,
+            "typeElementPropertyDeveloperName": null,
+            "contentValue": "{{databaseName}}",
+            "contentType": "ContentString",
+            "objectData": null
+        },
+        {
+            "valueElementId": null,
+            "typeElementId": null,
+            "typeElementPropertyId": null,
+            "developerName": "Port",
+            "typeElementDeveloperName": null,
+            "typeElementPropertyDeveloperName": null,
+            "contentValue": "{{port}}",
+            "contentType": "ContentNumber",
+            "objectData": null
+        },
+        {
+            "valueElementId": null,
+            "typeElementId": null,
+            "typeElementPropertyId": null,
+            "developerName": "Host",
+            "typeElementDeveloperName": null,
+            "typeElementPropertyDeveloperName": null,
+            "contentValue": "{{host}}",
+            "contentType": "ContentString",
+            "objectData": null
+        },
+        {
+            "valueElementId": null,
+            "typeElementId": null,
+            "typeElementPropertyId": null,
+            "developerName": "Database Schema",
+            "typeElementDeveloperName": null,
+            "typeElementPropertyDeveloperName": null,
+            "contentValue": "{{schema}}",
+            "contentType": "ContentString",
+            "objectData": null
+        },
+        {
+            "valueElementId": null,
+            "typeElementId": null,
+            "typeElementPropertyId": null,
+            "developerName": "Username",
+            "typeElementDeveloperName": null,
+            "typeElementPropertyDeveloperName": null,
+            "contentValue": "{{userName}}",
+            "contentType": "ContentString",
+            "objectData": null
+        },
+        {
+            "valueElementId": null,
+            "typeElementId": null,
+            "typeElementPropertyId": null,
+            "developerName": "No SSL",
+            "typeElementDeveloperName": null,
+            "typeElementPropertyDeveloperName": null,
+            "contentValue": "true",
+            "contentType": null,
+            "objectData": null
+        }
+    ],
+    "command": null,
+    "culture": {
+        "id": null,
+        "developerName": null,
+        "developerSummary": null,
+        "brand": null,
+        "language": "EN",
+        "country": "USA",
+        "variant": null
+    },
+    "listFilter": {
+        "id": null,
+        "filterByProvidedObjects": false,
+        "orderByPropertyDeveloperName": "id",
+        "orderByDirectionType": "",
+        "orderBy": null,
+        "limit": 0,
+        "offset": 0,
+        "search": "cc",
+        "searchCriteria": null,
+        "comparisonType": "OR",
+        "where": null,
+        "listFilters": null
+    },
+    "objectDataType": {
+        "typeElementId": "737809a7-5825-4b04-8d38-b271963732e5",
+        "developerName": "searchtest",
+        "properties": [
+            {
+                "developerName": "id",
+                "list": null
+            },
+            {
+                "developerName": "col_char",
+                "list": null
+            },
+            {
+                "developerName": "col_nchar",
+                "list": null
+            },
+            {
+                "developerName": "col_varchar",
+                "list": null
+            },
+            {
+                "developerName": "col_nvarchar",
+                "list": null
+            },
+            {
+                "developerName": "col_text",
+                "list": null
+            },
+            {
+                "developerName": "col_ntext",
+                "list": null
+            }
+        ]
+    },
+    "objectData": null
+}

--- a/src/test/resources/suites/sqlserver/search/varchar-response.json
+++ b/src/test/resources/suites/sqlserver/search/varchar-response.json
@@ -1,0 +1,72 @@
+{
+    "culture": null,
+    "hasMoreResults": false,
+    "objectData": [
+        {
+            "internalId": null,
+            "externalId": "eyJpZCI6IjMifQ==",
+            "developerName": "searchtest",
+            "typeElementId": null,
+            "order": 0,
+            "properties": [
+                {
+                    "typeElementPropertyId": null,
+                    "developerName": "id",
+                    "contentType": "ContentNumber",
+                    "contentValue": "3",
+                    "contentFormat": null,
+                    "objectData": []
+                },
+                {
+                    "typeElementPropertyId": null,
+                    "developerName": "col_char",
+                    "contentType": "ContentString",
+                    "contentValue": "xxxx",
+                    "contentFormat": null,
+                    "objectData": []
+                },
+                {
+                    "typeElementPropertyId": null,
+                    "developerName": "col_nchar",
+                    "contentType": "ContentString",
+                    "contentValue": "xxxx",
+                    "contentFormat": null,
+                    "objectData": []
+                },
+                {
+                    "typeElementPropertyId": null,
+                    "developerName": "col_varchar",
+                    "contentType": "ContentString",
+                    "contentValue": "cccc",
+                    "contentFormat": null,
+                    "objectData": []
+                },
+                {
+                    "typeElementPropertyId": null,
+                    "developerName": "col_nvarchar",
+                    "contentType": "ContentString",
+                    "contentValue": "xxxx",
+                    "contentFormat": null,
+                    "objectData": []
+                },
+                {
+                    "typeElementPropertyId": null,
+                    "developerName": "col_text",
+                    "contentType": "ContentString",
+                    "contentValue": "xxxx",
+                    "contentFormat": null,
+                    "objectData": []
+                },
+                {
+                    "typeElementPropertyId": null,
+                    "developerName": "col_ntext",
+                    "contentType": "ContentString",
+                    "contentValue": "xxxx",
+                    "contentFormat": null,
+                    "objectData": []
+                }
+            ],
+            "isSelected": false
+        }
+    ]
+}

--- a/src/test/resources/suites/sqlserver/search/xxxx-request.json
+++ b/src/test/resources/suites/sqlserver/search/xxxx-request.json
@@ -1,0 +1,160 @@
+{
+    "stateId": null,
+    "token": null,
+    "typeElementBindingId": null,
+    "authorization": {
+        "users": null,
+        "groups": null,
+        "runningAuthenticationId": null,
+        "globalAuthenticationType": "PUBLIC"
+    },
+    "configurationValues": [
+        {
+            "valueElementId": null,
+            "typeElementId": null,
+            "typeElementPropertyId": null,
+            "developerName": "Password",
+            "typeElementDeveloperName": null,
+            "typeElementPropertyDeveloperName": null,
+            "contentValue": "{{password}}",
+            "contentType": "ContentPassword",
+            "objectData": null
+        },
+        {
+            "valueElementId": null,
+            "typeElementId": null,
+            "typeElementPropertyId": null,
+            "developerName": "Database Type",
+            "typeElementDeveloperName": null,
+            "typeElementPropertyDeveloperName": null,
+            "contentValue": "{{databaseType}}",
+            "contentType": "ContentString",
+            "objectData": null
+        },
+        {
+            "valueElementId": null,
+            "typeElementId": null,
+            "typeElementPropertyId": null,
+            "developerName": "Database Name",
+            "typeElementDeveloperName": null,
+            "typeElementPropertyDeveloperName": null,
+            "contentValue": "{{databaseName}}",
+            "contentType": "ContentString",
+            "objectData": null
+        },
+        {
+            "valueElementId": null,
+            "typeElementId": null,
+            "typeElementPropertyId": null,
+            "developerName": "Port",
+            "typeElementDeveloperName": null,
+            "typeElementPropertyDeveloperName": null,
+            "contentValue": "{{port}}",
+            "contentType": "ContentNumber",
+            "objectData": null
+        },
+        {
+            "valueElementId": null,
+            "typeElementId": null,
+            "typeElementPropertyId": null,
+            "developerName": "Host",
+            "typeElementDeveloperName": null,
+            "typeElementPropertyDeveloperName": null,
+            "contentValue": "{{host}}",
+            "contentType": "ContentString",
+            "objectData": null
+        },
+        {
+            "valueElementId": null,
+            "typeElementId": null,
+            "typeElementPropertyId": null,
+            "developerName": "Database Schema",
+            "typeElementDeveloperName": null,
+            "typeElementPropertyDeveloperName": null,
+            "contentValue": "{{schema}}",
+            "contentType": "ContentString",
+            "objectData": null
+        },
+        {
+            "valueElementId": null,
+            "typeElementId": null,
+            "typeElementPropertyId": null,
+            "developerName": "Username",
+            "typeElementDeveloperName": null,
+            "typeElementPropertyDeveloperName": null,
+            "contentValue": "{{userName}}",
+            "contentType": "ContentString",
+            "objectData": null
+        },
+        {
+            "valueElementId": null,
+            "typeElementId": null,
+            "typeElementPropertyId": null,
+            "developerName": "No SSL",
+            "typeElementDeveloperName": null,
+            "typeElementPropertyDeveloperName": null,
+            "contentValue": "true",
+            "contentType": null,
+            "objectData": null
+        }
+    ],
+    "command": null,
+    "culture": {
+        "id": null,
+        "developerName": null,
+        "developerSummary": null,
+        "brand": null,
+        "language": "EN",
+        "country": "USA",
+        "variant": null
+    },
+    "listFilter": {
+        "id": null,
+        "filterByProvidedObjects": false,
+        "orderByPropertyDeveloperName": "id",
+        "orderByDirectionType": "",
+        "orderBy": null,
+        "limit": 0,
+        "offset": 0,
+        "search": "xx",
+        "searchCriteria": null,
+        "comparisonType": "OR",
+        "where": null,
+        "listFilters": null
+    },
+    "objectDataType": {
+        "typeElementId": "737809a7-5825-4b04-8d38-b271963732e5",
+        "developerName": "searchtest",
+        "properties": [
+            {
+                "developerName": "id",
+                "list": null
+            },
+            {
+                "developerName": "col_char",
+                "list": null
+            },
+            {
+                "developerName": "col_nchar",
+                "list": null
+            },
+            {
+                "developerName": "col_varchar",
+                "list": null
+            },
+            {
+                "developerName": "col_nvarchar",
+                "list": null
+            },
+            {
+                "developerName": "col_text",
+                "list": null
+            },
+            {
+                "developerName": "col_ntext",
+                "list": null
+            }
+        ]
+    },
+    "objectData": null
+}

--- a/src/test/resources/suites/sqlserver/search/xxxx-response.json
+++ b/src/test/resources/suites/sqlserver/search/xxxx-response.json
@@ -1,0 +1,402 @@
+{
+    "culture": null,
+    "hasMoreResults": false,
+    "objectData": [
+        {
+            "internalId": null,
+            "externalId": "eyJpZCI6IjEifQ==",
+            "developerName": "searchtest",
+            "typeElementId": null,
+            "order": 0,
+            "properties": [
+                {
+                    "typeElementPropertyId": null,
+                    "developerName": "id",
+                    "contentType": "ContentNumber",
+                    "contentValue": "1",
+                    "contentFormat": null,
+                    "objectData": []
+                },
+                {
+                    "typeElementPropertyId": null,
+                    "developerName": "col_char",
+                    "contentType": "ContentString",
+                    "contentValue": "aaaa",
+                    "contentFormat": null,
+                    "objectData": []
+                },
+                {
+                    "typeElementPropertyId": null,
+                    "developerName": "col_nchar",
+                    "contentType": "ContentString",
+                    "contentValue": "xxxx",
+                    "contentFormat": null,
+                    "objectData": []
+                },
+                {
+                    "typeElementPropertyId": null,
+                    "developerName": "col_varchar",
+                    "contentType": "ContentString",
+                    "contentValue": "xxxx",
+                    "contentFormat": null,
+                    "objectData": []
+                },
+                {
+                    "typeElementPropertyId": null,
+                    "developerName": "col_nvarchar",
+                    "contentType": "ContentString",
+                    "contentValue": "xxxx",
+                    "contentFormat": null,
+                    "objectData": []
+                },
+                {
+                    "typeElementPropertyId": null,
+                    "developerName": "col_text",
+                    "contentType": "ContentString",
+                    "contentValue": "xxxx",
+                    "contentFormat": null,
+                    "objectData": []
+                },
+                {
+                    "typeElementPropertyId": null,
+                    "developerName": "col_ntext",
+                    "contentType": "ContentString",
+                    "contentValue": "xxxx",
+                    "contentFormat": null,
+                    "objectData": []
+                }
+            ],
+            "isSelected": false
+        },
+        {
+            "internalId": null,
+            "externalId": "eyJpZCI6IjIifQ==",
+            "developerName": "searchtest",
+            "typeElementId": null,
+            "order": 0,
+            "properties": [
+                {
+                    "typeElementPropertyId": null,
+                    "developerName": "id",
+                    "contentType": "ContentNumber",
+                    "contentValue": "2",
+                    "contentFormat": null,
+                    "objectData": []
+                },
+                {
+                    "typeElementPropertyId": null,
+                    "developerName": "col_char",
+                    "contentType": "ContentString",
+                    "contentValue": "xxxx",
+                    "contentFormat": null,
+                    "objectData": []
+                },
+                {
+                    "typeElementPropertyId": null,
+                    "developerName": "col_nchar",
+                    "contentType": "ContentString",
+                    "contentValue": "bbbb",
+                    "contentFormat": null,
+                    "objectData": []
+                },
+                {
+                    "typeElementPropertyId": null,
+                    "developerName": "col_varchar",
+                    "contentType": "ContentString",
+                    "contentValue": "xxxx",
+                    "contentFormat": null,
+                    "objectData": []
+                },
+                {
+                    "typeElementPropertyId": null,
+                    "developerName": "col_nvarchar",
+                    "contentType": "ContentString",
+                    "contentValue": "xxxx",
+                    "contentFormat": null,
+                    "objectData": []
+                },
+                {
+                    "typeElementPropertyId": null,
+                    "developerName": "col_text",
+                    "contentType": "ContentString",
+                    "contentValue": "xxxx",
+                    "contentFormat": null,
+                    "objectData": []
+                },
+                {
+                    "typeElementPropertyId": null,
+                    "developerName": "col_ntext",
+                    "contentType": "ContentString",
+                    "contentValue": "xxxx",
+                    "contentFormat": null,
+                    "objectData": []
+                }
+            ],
+            "isSelected": false
+        },
+        {
+            "internalId": null,
+            "externalId": "eyJpZCI6IjMifQ==",
+            "developerName": "searchtest",
+            "typeElementId": null,
+            "order": 0,
+            "properties": [
+                {
+                    "typeElementPropertyId": null,
+                    "developerName": "id",
+                    "contentType": "ContentNumber",
+                    "contentValue": "3",
+                    "contentFormat": null,
+                    "objectData": []
+                },
+                {
+                    "typeElementPropertyId": null,
+                    "developerName": "col_char",
+                    "contentType": "ContentString",
+                    "contentValue": "xxxx",
+                    "contentFormat": null,
+                    "objectData": []
+                },
+                {
+                    "typeElementPropertyId": null,
+                    "developerName": "col_nchar",
+                    "contentType": "ContentString",
+                    "contentValue": "xxxx",
+                    "contentFormat": null,
+                    "objectData": []
+                },
+                {
+                    "typeElementPropertyId": null,
+                    "developerName": "col_varchar",
+                    "contentType": "ContentString",
+                    "contentValue": "cccc",
+                    "contentFormat": null,
+                    "objectData": []
+                },
+                {
+                    "typeElementPropertyId": null,
+                    "developerName": "col_nvarchar",
+                    "contentType": "ContentString",
+                    "contentValue": "xxxx",
+                    "contentFormat": null,
+                    "objectData": []
+                },
+                {
+                    "typeElementPropertyId": null,
+                    "developerName": "col_text",
+                    "contentType": "ContentString",
+                    "contentValue": "xxxx",
+                    "contentFormat": null,
+                    "objectData": []
+                },
+                {
+                    "typeElementPropertyId": null,
+                    "developerName": "col_ntext",
+                    "contentType": "ContentString",
+                    "contentValue": "xxxx",
+                    "contentFormat": null,
+                    "objectData": []
+                }
+            ],
+            "isSelected": false
+        },
+        {
+            "internalId": null,
+            "externalId": "eyJpZCI6IjQifQ==",
+            "developerName": "searchtest",
+            "typeElementId": null,
+            "order": 0,
+            "properties": [
+                {
+                    "typeElementPropertyId": null,
+                    "developerName": "id",
+                    "contentType": "ContentNumber",
+                    "contentValue": "4",
+                    "contentFormat": null,
+                    "objectData": []
+                },
+                {
+                    "typeElementPropertyId": null,
+                    "developerName": "col_char",
+                    "contentType": "ContentString",
+                    "contentValue": "xxxx",
+                    "contentFormat": null,
+                    "objectData": []
+                },
+                {
+                    "typeElementPropertyId": null,
+                    "developerName": "col_nchar",
+                    "contentType": "ContentString",
+                    "contentValue": "xxxx",
+                    "contentFormat": null,
+                    "objectData": []
+                },
+                {
+                    "typeElementPropertyId": null,
+                    "developerName": "col_varchar",
+                    "contentType": "ContentString",
+                    "contentValue": "xxxx",
+                    "contentFormat": null,
+                    "objectData": []
+                },
+                {
+                    "typeElementPropertyId": null,
+                    "developerName": "col_nvarchar",
+                    "contentType": "ContentString",
+                    "contentValue": "dddd",
+                    "contentFormat": null,
+                    "objectData": []
+                },
+                {
+                    "typeElementPropertyId": null,
+                    "developerName": "col_text",
+                    "contentType": "ContentString",
+                    "contentValue": "xxxx",
+                    "contentFormat": null,
+                    "objectData": []
+                },
+                {
+                    "typeElementPropertyId": null,
+                    "developerName": "col_ntext",
+                    "contentType": "ContentString",
+                    "contentValue": "xxxx",
+                    "contentFormat": null,
+                    "objectData": []
+                }
+            ],
+            "isSelected": false
+        },
+        {
+            "internalId": null,
+            "externalId": "eyJpZCI6IjUifQ==",
+            "developerName": "searchtest",
+            "typeElementId": null,
+            "order": 0,
+            "properties": [
+                {
+                    "typeElementPropertyId": null,
+                    "developerName": "id",
+                    "contentType": "ContentNumber",
+                    "contentValue": "5",
+                    "contentFormat": null,
+                    "objectData": []
+                },
+                {
+                    "typeElementPropertyId": null,
+                    "developerName": "col_char",
+                    "contentType": "ContentString",
+                    "contentValue": "xxxx",
+                    "contentFormat": null,
+                    "objectData": []
+                },
+                {
+                    "typeElementPropertyId": null,
+                    "developerName": "col_nchar",
+                    "contentType": "ContentString",
+                    "contentValue": "xxxx",
+                    "contentFormat": null,
+                    "objectData": []
+                },
+                {
+                    "typeElementPropertyId": null,
+                    "developerName": "col_varchar",
+                    "contentType": "ContentString",
+                    "contentValue": "xxxx",
+                    "contentFormat": null,
+                    "objectData": []
+                },
+                {
+                    "typeElementPropertyId": null,
+                    "developerName": "col_nvarchar",
+                    "contentType": "ContentString",
+                    "contentValue": "xxxx",
+                    "contentFormat": null,
+                    "objectData": []
+                },
+                {
+                    "typeElementPropertyId": null,
+                    "developerName": "col_text",
+                    "contentType": "ContentString",
+                    "contentValue": "eeee",
+                    "contentFormat": null,
+                    "objectData": []
+                },
+                {
+                    "typeElementPropertyId": null,
+                    "developerName": "col_ntext",
+                    "contentType": "ContentString",
+                    "contentValue": "xxxx",
+                    "contentFormat": null,
+                    "objectData": []
+                }
+            ],
+            "isSelected": false
+        },
+        {
+            "internalId": null,
+            "externalId": "eyJpZCI6IjYifQ==",
+            "developerName": "searchtest",
+            "typeElementId": null,
+            "order": 0,
+            "properties": [
+                {
+                    "typeElementPropertyId": null,
+                    "developerName": "id",
+                    "contentType": "ContentNumber",
+                    "contentValue": "6",
+                    "contentFormat": null,
+                    "objectData": []
+                },
+                {
+                    "typeElementPropertyId": null,
+                    "developerName": "col_char",
+                    "contentType": "ContentString",
+                    "contentValue": "xxxx",
+                    "contentFormat": null,
+                    "objectData": []
+                },
+                {
+                    "typeElementPropertyId": null,
+                    "developerName": "col_nchar",
+                    "contentType": "ContentString",
+                    "contentValue": "xxxx",
+                    "contentFormat": null,
+                    "objectData": []
+                },
+                {
+                    "typeElementPropertyId": null,
+                    "developerName": "col_varchar",
+                    "contentType": "ContentString",
+                    "contentValue": "xxxx",
+                    "contentFormat": null,
+                    "objectData": []
+                },
+                {
+                    "typeElementPropertyId": null,
+                    "developerName": "col_nvarchar",
+                    "contentType": "ContentString",
+                    "contentValue": "xxxx",
+                    "contentFormat": null,
+                    "objectData": []
+                },
+                {
+                    "typeElementPropertyId": null,
+                    "developerName": "col_text",
+                    "contentType": "ContentString",
+                    "contentValue": "xxxx",
+                    "contentFormat": null,
+                    "objectData": []
+                },
+                {
+                    "typeElementPropertyId": null,
+                    "developerName": "col_ntext",
+                    "contentType": "ContentString",
+                    "contentValue": "ffff",
+                    "contentFormat": null,
+                    "objectData": []
+                }
+            ],
+            "isSelected": false
+        }
+   ]
+}


### PR DESCRIPTION
The problem was because the schema on the flowconnect database used columns with the data type NCHAR and these were not considered as suitable candidates for searching. It only searched,

- VARCHAR
- NVARCHAR
- LONGVARCHAR
- LONGNVARCHAR
- 

To fix the problem I’ve added support for NCHAR and CHAR

The change consists of just a couple of lines in src/main/java/com/manywho/services/sql/services/filter/QueryFilterConditions.java

The remaining changes are searching tests for MySQL, Postgres and SQl Server