### PR TITLE
ECS Migration - hosting reqs

### DIFF
--- a/src/main/java/com/manywho/services/sql/Application.java
+++ b/src/main/java/com/manywho/services/sql/Application.java
@@ -23,7 +23,7 @@ public class Application extends Servlet3Server  {
 
         server.addModule(new ApplicationSqlModule());
         server.setApplication(Application.class);
-        server.start();
+        server.start("/api/sql/2");
     }
 
     private static void checkDriverClass(String driverRef) {


### PR DESCRIPTION
Change to force the API to listen on api/sql/2 only (api/sql/1 is no longer supported)